### PR TITLE
Chore: edit next/image configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,26 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['www.google.com', 'i.natgeofe.com']
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'i.pinimg.com',
+        port: '',
+        pathname: '/**'
+      },
+      {
+        protocol: 'https',
+        hostname: 'www.google.com',
+        port: '',
+        pathname: '/**'
+      },
+      {
+        protocol: 'https',
+        hostname: 'i.natgeofe.com',
+        port: '',
+        pathname: '/**'
+      }
+    ]
   },
   webpack: config => {
     config.module.rules.push({


### PR DESCRIPTION
[next/image configuration](https://nextjs.org/docs/messages/next-image-unconfigured-host)

next.config 내부에 외부 이미지 허용 설정시, 기존 사용중이었던 domain에 string을 추가하는 방법은 deprecated되었다고 합니다.
remotePatterns를 사용하도록 안내되어있어 그에 맞춰 수정했습니다!