### PR TITLE
Fix: root layout 에서 nesting layout으로 BottomNavBar 이동

### DIFF
--- a/src/app/community/layout.tsx
+++ b/src/app/community/layout.tsx
@@ -1,0 +1,16 @@
+import BottomNavBar from '@/components/ui/BottomNavBar';
+
+export default function CommunityLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      {children}
+      <div className="fixed bottom-0 left-0 right-0 z-10 flex justify-center">
+        <BottomNavBar />
+      </div>
+    </section>
+  );
+}

--- a/src/app/diary/layout.tsx
+++ b/src/app/diary/layout.tsx
@@ -1,0 +1,16 @@
+import BottomNavBar from '@/components/ui/BottomNavBar';
+
+export default function DiaryLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="h-screen bg-gr-50">
+      {children}
+      <div className="fixed bottom-0 left-0 right-0 z-10 flex justify-center">
+        <BottomNavBar />
+      </div>
+    </section>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,9 +34,6 @@ export default function RootLayout({
           </Providers>
         </div>
         <Toaster />
-        <div className="fixed bottom-0 left-0 right-0 z-[100] flex justify-center">
-          <BottomNavBar />
-        </div>
       </body>
     </html>
   );

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,0 +1,16 @@
+import BottomNavBar from '@/components/ui/BottomNavBar';
+
+export default function ProfileLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      {children}
+      <div className="fixed bottom-0 left-0 right-0 z-10 flex justify-center">
+        <BottomNavBar />
+      </div>
+    </section>
+  );
+}

--- a/src/app/zip/layout.tsx
+++ b/src/app/zip/layout.tsx
@@ -1,0 +1,12 @@
+import BottomNavBar from '@/components/ui/BottomNavBar';
+
+export default function ZipLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <section>
+      {children}
+      <div className="fixed bottom-0 left-0 right-0 z-10 flex justify-center">
+        <BottomNavBar />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new layout components: `CommunityLayout`, `DiaryLayout`, `ProfileLayout`, and `ZipLayout`, each featuring a fixed-position navigation bar for improved user navigation.
  
- **Bug Fixes**
	- Removed the `BottomNavBar` from the `RootLayout` to streamline the overall layout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->