### PR TITLE
Fix: 고양이 상세 일지 내것만 보이게 수정(isMine 필드값 추가)

### DIFF
--- a/src/app/zip/[id]/page.tsx
+++ b/src/app/zip/[id]/page.tsx
@@ -65,7 +65,7 @@ const ZipDiaryPage = ({ params: { id } }: { params: { id: number } }) => {
             ))}
           </div>
         </DetailCardLayout>
-        {catDetail.diaries !== undefined && (
+        {catDetail.isMine && (
           <DetailCardLayout
             titleObj={{ title: '일지' }}
             btnObj={{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The diary section in the `ZipDiaryPage` will now only display for users who are the owners of the cat, enhancing privacy and relevance of content.
  
- **Bug Fixes**
	- Improved conditional rendering logic for displaying diaries, ensuring users see only their own content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->