### PR TITLE
Fix: isCoParented 필드 삭제

### DIFF
--- a/src/components/zip/ZipCard.tsx
+++ b/src/components/zip/ZipCard.tsx
@@ -12,7 +12,6 @@ interface ZipCardProps extends CatListObj {
 const ZipCard = ({
   imageUrl,
   name,
-  isCoParented,
   coParentedCount,
   dDay,
   sex,
@@ -28,10 +27,10 @@ const ZipCard = ({
             content="TNR"
           />
         )}
-        {isCoParented && (
+        {coParentedCount !== 0 && (
           <div className="flex items-center rounded-md bg-gr-transparent-black py-[2px] pl-[2px] pr-1 text-gr-white">
             <Label.Icon src="/images/icons/share.svg" />
-            <Label.Text content={coParentedCount.toString()} className="" />
+            <Label.Text content={coParentedCount.toString()} />
           </div>
         )}
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display logic for co-parented count in the ZipCard component, ensuring it only appears when there is at least one co-parented instance.
  
- **Bug Fixes**
	- Removed unnecessary boolean flag for co-parented display, improving clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->