### PR TITLE
Fix: 다른 유저 모음집의 공동집사 가리기

### DIFF
--- a/src/app/zip/[id]/page.tsx
+++ b/src/app/zip/[id]/page.tsx
@@ -49,22 +49,24 @@ const ZipDiaryPage = ({ params: { id } }: { params: { id: number } }) => {
         <article className="rounded-16">
           <ZipDetailCatCard {...catDetail} />
         </article>
-        <DetailCardLayout
-          titleObj={{
-            title: '공동집사',
-            onClick: () => setCoParentsBottomSheet(true)
-          }}
-          btnObj={{
-            text: '함께할 공동집사 찾기',
-            onClick: () => setShowCoParentsModal(true)
-          }}
-        >
-          <div className="flex pt-2">
-            {catDetail.coParents?.map((coParent: CoParent) => (
-              <ZipDetailCoParents key={coParent.memberId} {...coParent} />
-            ))}
-          </div>
-        </DetailCardLayout>
+        {catDetail.isMine && (
+          <DetailCardLayout
+            titleObj={{
+              title: '공동집사',
+              onClick: () => setCoParentsBottomSheet(true)
+            }}
+            btnObj={{
+              text: '함께할 공동집사 찾기',
+              onClick: () => setShowCoParentsModal(true)
+            }}
+          >
+            <div className="flex pt-2">
+              {catDetail.coParents?.map((coParent: CoParent) => (
+                <ZipDetailCoParents key={coParent.memberId} {...coParent} />
+              ))}
+            </div>
+          </DetailCardLayout>
+        )}
         {catDetail.isMine && (
           <DetailCardLayout
             titleObj={{ title: '일지' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility controls for the `ZipDiaryPage`: co-parent details and diary sections are now displayed only to the cat owner, improving user experience and ownership clarity.
- **Bug Fixes**
	- Maintained error handling and loading states to ensure consistent user feedback during data fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->