### PR TITLE
fix: 모음집 내부 고양이 삭제 UX 개선

### DIFF
--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -82,11 +82,11 @@ const DiaryDetailPage = ({ params: { id } }: { params: { id: number } }) => {
             <h5 className="text-end text-body-4 text-gr-500">
               {diaryDetail?.memberNickname} • {diaryDetail?.caredTime}
             </h5>
-            <div className="flex h-[300px] w-full">
-              {diaryDetail?.images && (
+            {diaryDetail?.images.length > 0 && (
+              <div className="flex h-[300px] w-full">
                 <Carousel images={diaryDetail?.images} style="rounded-16" />
-              )}
-            </div>
+              </div>
+            )}
             <h4 className="w-full whitespace-pre-line text-body-3 text-gr-black">
               {diaryDetail?.content}
             </h4>

--- a/src/app/zip/[id]/page.tsx
+++ b/src/app/zip/[id]/page.tsx
@@ -104,9 +104,17 @@ const ZipDiaryPage = ({ params: { id } }: { params: { id: number } }) => {
         heightPercent={['50%', '40%']}
         name={catDetail?.name}
         memberId={catDetail?.id}
-        onDelete={() => {
-          deleteCat(catDetail?.id);
-          location.href = '/zip';
+        onDelete={async () => {
+          try {
+            await deleteCat(catDetail?.id);
+            toast({ description: '삭제되었습니다.', duration: 1000 });
+            router.replace('/zip');
+          } catch (e) {
+            toast({
+              description: '삭제에 실패했습니다. 잠시 후 다시 시도해주세요.',
+              duration: 1500
+            });
+          }
         }}
         onEdit={() => {
           router.push(`/zip/${id}/edit?catId=${catDetail?.id}`);

--- a/src/components/diary/DiaryWriteModal.tsx
+++ b/src/components/diary/DiaryWriteModal.tsx
@@ -260,8 +260,11 @@ const DiaryWriteModal = ({
   const editDiaryMutation = useMutation({
     mutationFn: (reqObj: { id: number; diary: DiaryRegisterReqObj }) =>
       editDiaryOnServer(reqObj),
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['diaryDetail'] });
+      queryClient.invalidateQueries({
+        predicate: q => q.queryKey[0] === 'diaries'
+      });
       toast({
         description: '일지가 성공적으로 수정되었습니다.'
       });

--- a/src/services/cat.ts
+++ b/src/services/cat.ts
@@ -341,7 +341,19 @@ export const deleteCat = async (id: number) => {
 
   try {
     const response = await fetchAuth(`/cats/${id}`, requestOptions);
-    return response.body;
+    if (!response.ok) {
+      const msg = await (async () => {
+        try {
+          const body = await response.text();
+          return body || '요청 실패';
+        } catch {
+          return '요청 실패';
+        }
+      })();
+
+      throw new Error(msg);
+    }
+    return true;
   } catch (error) {
     console.error(error);
     if (error instanceof Error) {


### PR DESCRIPTION
## 변경사항
- DiaryDetailPage에서 이미지가 있을 때만 캐러셀을 표시하도록 했습니다.
- Zip 상세 페이지에서 고양이 삭제를 비동기 처리하고, 성공/실패 토스트를 추가했으며 `router.replace('/zip')`를 사용했습니다.
- DiaryWriteModal에서 `onSuccess`를 async로 변경하고, `diaryDetail` 및 `diaries` 캐시를 무효화한 뒤 성공 토스트를 표시했습니다.