### PR TITLE
feat: 주요 상세 페이지 서버 컴포넌트 전환

### DIFF
--- a/src/app/community/[slug]/page.tsx
+++ b/src/app/community/[slug]/page.tsx
@@ -1,197 +1,93 @@
-'use client';
+import { getFeedDetail, getFeedComments } from '@/services/community';
+import CommunityDetailClient from '@/components/community/detail/CommunityDetailClient';
+import { FeedType, CommentType } from '@/types/communityType';
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
-import WriteComment from '@/components/community/detail/WriteComment';
-import { Fragment, useEffect, useState, useRef } from 'react';
-import FeedCard from '@/components/community/FeedCard';
-import Comment from '@/components/community/detail/Comment';
-import MoreBtnBottomSheet from '@/components/community/MoreBtnBottomSheet';
-import FeedWriteModal from '@/components/community/FeedWriteModal';
-import { useQuery } from '@tanstack/react-query';
-import { getFeedDetail } from '@/services/community';
-import Topbar from '@/components/ui/Topbar';
-import { useRouter } from 'next/navigation';
-import { getFeedComments } from '@/services/community';
-import { CommentType } from '@/types/communityType';
-import useFeedMutations from '@/hooks/community/useFeedMutations';
-import useCommentMutation from '@/hooks/community/useCommentMutation';
+interface PageProps {
+  params: { slug: string };
+}
 
-const DetailPage = ({ params: { slug } }: { params: { slug: number } }) => {
-  const router = useRouter();
+export async function generateMetadata({
+  params
+}: PageProps): Promise<Metadata> {
+  if (params.slug === 'write') {
+    return {
+      title: '피드 작성 | 냥집사',
+      description: '냥집사 커뮤니티 피드 작성'
+    };
+  }
 
-  const [, setBottomSheetHeight] = useState<number>(0);
-  const bottomSheetRef = useRef<HTMLDivElement>(null);
+  const slug = Number(params.slug);
 
-  const [editBottomSheet, setEditBottomSheet] = useState(false);
-  const [showWriteModal, setShowWriteModal] = useState(false);
-  const [selectedComment, setSelectedComment] = useState<CommentType>();
-  const [parentCommentId, setParentCommentId] = useState<number | null>(null);
-  const [isReplying, setIsReplying] = useState(false);
+  if (!params.slug || isNaN(slug)) {
+    return {
+      title: '피드 | 냥집사',
+      description: '냥집사 커뮤니티 피드'
+    };
+  }
 
-  const {
-    data: feedDetail,
-    isError: isFeedDetailError,
-    error: feedDetailError
-  } = useQuery({
-    queryKey: ['feedDetail', slug],
-    queryFn: () => getFeedDetail(slug),
-    staleTime: 0
-  });
+  try {
+    const feedDetail = await getFeedDetail(slug);
 
-  const {
-    data: commentsData,
-    isError: isCommentsDataError,
-    error: commentsDataError
-  } = useQuery({
-    queryKey: ['comments', slug],
-    queryFn: () => getFeedComments(slug),
-    staleTime: 0
-  });
+    return {
+      title: `${feedDetail.writerNickname}님의 피드 | 냥집사`,
+      description: feedDetail.content.slice(0, 100) + '...',
+      openGraph: {
+        title: `${feedDetail.writerNickname}님의 피드`,
+        description: feedDetail.content.slice(0, 100) + '...',
+        images: feedDetail.images?.length > 0 ? feedDetail.images : [],
+        type: 'article'
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${feedDetail.writerNickname}님의 피드`,
+        description: feedDetail.content.slice(0, 100) + '...',
+        images: feedDetail.images?.length > 0 ? feedDetail.images : []
+      }
+    };
+  } catch (error) {
+    return {
+      title: '피드 | 냥집사',
+      description: '냥집사 커뮤니티 피드'
+    };
+  }
+}
 
-  const { deleteFeed, blockFeed, reportFeed, toggleLikeFeed, toggleBookmark } =
-    useFeedMutations(['feeds', 'feedDetail']);
+const DetailPage = async ({ params }: PageProps) => {
+  if (
+    params.slug === 'write' ||
+    params.slug === 'null' ||
+    params.slug === 'undefined'
+  ) {
+    notFound();
+  }
 
-  const { blockComment, reportComment, deleteComment } = useCommentMutation();
+  const slug = Number(params.slug);
 
-  const comments = (commentsData as any)?.items || [];
+  if (!params.slug || isNaN(slug) || slug <= 0) {
+    notFound();
+  }
 
-  useEffect(() => {
-    if (bottomSheetRef.current) {
-      const height = bottomSheetRef.current.scrollHeight;
-      setBottomSheetHeight(height);
-    }
-  }, [editBottomSheet]);
+  try {
+    const [feedDetail, commentsData] = await Promise.all([
+      getFeedDetail(slug),
+      getFeedComments(slug)
+    ]);
 
-  const handleReply = (commentId: number) => {
-    setParentCommentId(commentId);
-    setIsReplying(true);
-  };
+    const comments = (commentsData as any)?.items || [];
 
-  const handleCancelReply = () => {
-    setParentCommentId(null);
-    setIsReplying(false);
-  };
-
-  if (isFeedDetailError) throw feedDetailError;
-  if (isCommentsDataError) throw commentsDataError;
-
-  return (
-    <div className="fixed top-0 z-50 mx-auto flex h-app w-full max-w-[640px] flex-col bg-gr-white">
-      <Topbar type="three" className="flex-none">
-        <Topbar.Back onClick={() => router.back()} />
-        <Topbar.Title title="피드" />
-        <Topbar.Empty />
-      </Topbar>
-      <div className="flex-1 overflow-y-auto">
-        <div className="pb-24 pt-12">
-          {feedDetail && (
-            <FeedCard
-              variant="detail"
-              content={feedDetail}
-              openBottomSheet={() => {
-                setEditBottomSheet(true);
-              }}
-              toggleLikeFeed={() => toggleLikeFeed(feedDetail)}
-              toggleBookmark={() => toggleBookmark(feedDetail)}
-              hasUserArea
-            />
-          )}
-          {comments.length === 0 && (
-            <p className="py-8 text-center text-sm text-gr-300">
-              아직 댓글이 없어요
-              <br />
-              가장 먼저 댓글을 남겨보세요.
-            </p>
-          )}
-
-          {comments.map((comment: CommentType) => (
-            <div key={comment.id} className="py-3">
-              <Comment
-                comment={comment}
-                setEditBottomSheet={setEditBottomSheet}
-                setSelectedComment={setSelectedComment}
-                onReply={handleReply}
-              />
-              {isReplying && parentCommentId === comment.id && feedDetail && (
-                <WriteComment
-                  feedId={feedDetail.id}
-                  parentCommentId={parentCommentId}
-                  onCancel={handleCancelReply}
-                />
-              )}
-              {comment.replies?.map((reply: CommentType) => (
-                <Fragment key={reply.id}>
-                  {isReplying && parentCommentId === reply.id && feedDetail && (
-                    <WriteComment
-                      feedId={feedDetail.id}
-                      parentCommentId={parentCommentId}
-                      onCancel={handleCancelReply}
-                    />
-                  )}
-                </Fragment>
-              ))}
-            </div>
-          ))}
-        </div>
-      </div>
-      <div className="z-[60] flex-none border-t border-gr-100 bg-gr-white shadow-sm">
-        {!isReplying && feedDetail && <WriteComment feedId={feedDetail.id} />}
-      </div>
-      {showWriteModal && (
-        <FeedWriteModal
-          onClose={() => setShowWriteModal(false)}
-          feedDetail={feedDetail}
-        />
-      )}
-      <MoreBtnBottomSheet
-        type={selectedComment ? 'comment' : 'feed'}
-        isVisible={editBottomSheet}
-        setIsVisible={() => {
-          setEditBottomSheet(!editBottomSheet);
-        }}
-        heightPercent={['50%', '60%']}
-        name={
-          selectedComment
-            ? selectedComment?.memberNickname
-            : feedDetail?.writerNickname
-        }
-        memberId={
-          selectedComment ? selectedComment?.memberId : feedDetail?.writerId
-        }
-        onDelete={() => {
-          if (selectedComment && feedDetail) {
-            deleteComment({
-              postId: feedDetail.id,
-              commentId: selectedComment.id
-            });
-          } else if (feedDetail) {
-            deleteFeed(feedDetail);
-          }
-        }}
-        onEdit={() => {
-          if (!selectedComment) {
-            setShowWriteModal(true);
-          }
-        }}
-        onBlock={() => {
-          if (selectedComment && feedDetail) {
-            blockComment(feedDetail.id);
-          } else if (feedDetail) {
-            blockFeed(feedDetail);
-          }
-        }}
-        onReport={() => {
-          if (selectedComment && feedDetail) {
-            reportComment(feedDetail.id, selectedComment.id);
-          } else if (feedDetail) {
-            reportFeed(feedDetail);
-          }
-        }}
-        showWriteModal={
-          selectedComment ? undefined : () => setShowWriteModal(true)
-        }
+    return (
+      <CommunityDetailClient
+        feedDetail={feedDetail as FeedType}
+        comments={comments as CommentType[]}
+        slug={slug}
       />
-    </div>
-  );
+    );
+  } catch (error) {
+    console.error('피드 상세 로딩 실패:', error);
+    throw error;
+  }
 };
 
 export default DetailPage;

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -45,7 +45,12 @@ export default function DiaryWritePage() {
     error
   } = useQuery({
     queryKey: ['feedDetail', feedId],
-    queryFn: () => getFeedDetail(feedId as number),
+    queryFn: () => {
+      if (!feedId || isNaN(feedId)) {
+        throw new Error('유효하지 않은 피드 ID입니다.');
+      }
+      return getFeedDetail(feedId);
+    },
     enabled: isClient && typeof feedId === 'number' && !isNaN(feedId),
     staleTime: 0
   });

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -1,155 +1,65 @@
-'use client';
+import { getDiaryDetail } from '@/services/diary';
+import DiaryDetailClient from '@/components/diary/DiaryDetailClient';
+import { Metadata } from 'next';
 
-import React, { useEffect, useState } from 'react';
-import Topbar from '@/components/ui/Topbar';
-import Carousel from '@/components/ui/Carousel';
-import Label from '@/components/ui/Label';
-import MoreBtnBottomSheet from '@/components/community/MoreBtnBottomSheet';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { deleteDiaryOnServer, getDiaryDetail } from '@/services/diary';
-import { useRouter } from 'next/navigation';
-import { CatType } from '@/types/cat';
-import Image from 'next/image';
+interface PageProps {
+  params: { id: string };
+}
 
-const DiaryDetailPage = ({ params: { id } }: { params: { id: number } }) => {
-  const router = useRouter();
+export async function generateMetadata({
+  params
+}: PageProps): Promise<Metadata> {
+  const id = Number(params.id);
 
-  const [editBottomSheet, setEditBottomSheet] = useState(false);
+  if (!params.id || isNaN(id)) {
+    return {
+      title: '일지 | 냥집사',
+      description: '냥집사 일지'
+    };
+  }
 
-  const {
-    data: diaryDetail,
-    isLoading,
-    isError
-  } = useQuery({
-    queryKey: ['diaryDetail', id],
-    queryFn: () => getDiaryDetail(id),
-    staleTime: 0
-  });
+  try {
+    const diaryDetail = await getDiaryDetail(id);
 
-  useEffect(() => {
-    if (!diaryDetail) return;
-  }, [diaryDetail, id]);
-
-  const deleteDidary = () => {
-    deleteDiaryMutation.mutate(id);
-  };
-  const deleteDiaryMutation = useMutation({
-    mutationFn: (id: number) => deleteDiaryOnServer(id),
-    onSuccess: (response: any) => {
-      if (response.status === 'OK') {
-        router.push('/diary');
-      } else {
-        console.error('일지 삭제 중 오류:', response.message);
+    return {
+      title: `${diaryDetail.caredDate} 일지 | 냥집사`,
+      description: diaryDetail.content.slice(0, 100) + '...',
+      openGraph: {
+        title: `${diaryDetail.caredDate} 일지`,
+        description: diaryDetail.content.slice(0, 100) + '...',
+        images: diaryDetail.images?.length > 0 ? diaryDetail.images : [],
+        type: 'article'
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${diaryDetail.caredDate} 일지`,
+        description: diaryDetail.content.slice(0, 100) + '...',
+        images: diaryDetail.images?.length > 0 ? diaryDetail.images : []
       }
-    },
-    onError: (error: any) => {
-      console.error('일지 삭제 중 오류:', error);
-    }
-  });
+    };
+  } catch (error) {
+    return {
+      title: '일지 | 냥집사',
+      description: '냥집사 일지'
+    };
+  }
+}
 
-  if (isLoading) {
-    return (
-      <div className="fixed left-1/2 top-0 z-50 h-screen w-screen max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
-        <div className="flex h-full items-center justify-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-pr-500 border-t-transparent" />
-        </div>
-      </div>
-    );
+const DiaryDetailPage = async ({ params }: PageProps) => {
+  const id = Number(params.id);
+
+  if (!params.id || isNaN(id)) {
+    throw new Error('유효하지 않은 일지 ID입니다.');
   }
 
-  if (isError) {
-    return (
-      <div className="fixed left-1/2 top-0 z-50 h-screen w-screen max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
-        <div className="flex h-full items-center justify-center">
-          <div className="text-body-2 text-gr-500">
-            일지를 불러오는데 실패했습니다.
-          </div>
-        </div>
-      </div>
-    );
-  }
+  try {
+    const diaryDetail = await getDiaryDetail(id);
 
-  return (
-    <div className="relative mx-auto">
-      <div className="fixed left-1/2 top-0 z-50 h-screen w-screen max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
-        <Topbar type="two">
-          <Topbar.Back onClick={() => router.back()} />
-          <Topbar.Title title={diaryDetail?.caredDate} />
-          <Topbar.More onClick={() => setEditBottomSheet(true)} />
-        </Topbar>
-        <div className="m-auto max-w-[640px]">
-          <section className="flex flex-col gap-4 border-b border-gr-100 px-4 pb-8 pt-12">
-            <h5 className="text-end text-body-4 text-gr-500">
-              {diaryDetail?.memberNickname} • {diaryDetail?.caredTime}
-            </h5>
-            {diaryDetail?.images.length > 0 && (
-              <div className="flex h-[300px] w-full">
-                <Carousel images={diaryDetail?.images} style="rounded-16" />
-              </div>
-            )}
-            <h4 className="w-full whitespace-pre-line text-body-3 text-gr-black">
-              {diaryDetail?.content}
-            </h4>
-            <article className="mb-2 flex items-center justify-start gap-1">
-              {diaryDetail?.isFeed && (
-                <Label.Text
-                  content="🐟 사료"
-                  className="rounded-md bg-gr-50 px-[6px] pb-1 pt-[5px]"
-                />
-              )}
-              {diaryDetail?.isGivenWater && (
-                <Label.Text
-                  content="💧 물"
-                  className="rounded-md bg-gr-50 px-[6px] pb-1 pt-[5px]"
-                />
-              )}
-            </article>
-          </section>
-          <section className="px-4 pb-[120px] pt-4">
-            <h3 className="py-3 text-heading-5 text-gr-900">
-              태그된 고양이
-              <span className="pl-1 text-pr-500">
-                {diaryDetail?.taggedCats?.length}
-              </span>
-            </h3>
-            {diaryDetail?.taggedCats?.map((cat: CatType) => (
-              <article key={cat.id} className="flex items-center gap-4 py-2">
-                <Image
-                  src={cat.imageUrl}
-                  alt="cat-image"
-                  width={48}
-                  height={48}
-                  className="h-12 w-12 rounded-full"
-                />
-                <div className="flex items-center gap-2">
-                  <h4 className="text-body-3 text-gr-900">{cat.name}</h4>
-                  <Image
-                    src={`/images/icons/gender-${cat.sex}.svg`}
-                    alt="cat-gender"
-                    width={16}
-                    height={16}
-                    className={`rounded-full ${
-                      cat.sex === 'F' ? 'bg-[#FFF2F1]' : 'bg-[#ECF5FF]'
-                    }`}
-                  />
-                </div>
-              </article>
-            ))}
-          </section>
-        </div>
-        <MoreBtnBottomSheet
-          type="diary"
-          isVisible={editBottomSheet}
-          setIsVisible={() => setEditBottomSheet(!editBottomSheet)}
-          heightPercent={['50%', '40%']}
-          name={diaryDetail?.memberNickname}
-          memberId={diaryDetail?.memberId}
-          onDelete={deleteDidary}
-          onEdit={() => router.push(`/diary/${id}/edit`)}
-        />
-      </div>
-    </div>
-  );
+    return <DiaryDetailClient diaryDetail={diaryDetail} id={id} />;
+  } catch (error) {
+    console.error('일지 상세 로딩 실패:', error);
+    throw error;
+  }
 };
 
 export default DiaryDetailPage;

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,21 +1,59 @@
-'use client';
-import { useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
-import ProfileDetail from '@/components/profile/ProfileDetail';
 import { getClickedUserProfile, getOtherUserFeeds } from '@/services/profile';
-import Profile from '@/components/ui/Profile';
-import Topbar from '@/components/ui/Topbar';
-import Button from '@/components/ui/Button';
-import { FeedType } from '@/types/communityType';
-import FeedCard from '@/components/community/FeedCard';
-import useFeedMutations from '@/hooks/community/useFeedMutations';
-import ProfileSkeleton from '@/components/profile/ProfileSkeleton';
-import ProfileFeedSkeleton from '@/components/profile/ProfileFeedSkeleton';
-import RightIcon from '../../../../public/images/icons/right.svg';
-import { DEFAULT_PROFILE_IMAGE_SRC } from '@/constants/general';
+import ProfileDetailClient from '@/components/profile/ProfileDetailClient';
+import { Metadata } from 'next';
 
-const ProfileIdPage = ({ params: { id } }: { params: { id: number } }) => {
-  const router = useRouter();
+interface PageProps {
+  params: { id: string };
+}
+
+export async function generateMetadata({
+  params
+}: PageProps): Promise<Metadata> {
+  const id = Number(params.id);
+
+  if (!params.id || isNaN(id)) {
+    return {
+      title: '프로필 | 냥집사',
+      description: '냥집사 유저 프로필'
+    };
+  }
+
+  try {
+    const profileData = await getClickedUserProfile(id);
+
+    return {
+      title: `${profileData.nickname}님의 프로필 | 냥집사`,
+      description: `고양이 ${profileData.catCount}마리, 게시물 ${profileData.postCount}개`,
+      openGraph: {
+        title: `${profileData.nickname}님의 프로필`,
+        description: `고양이 ${profileData.catCount}마리, 게시물 ${profileData.postCount}개`,
+        images: profileData.profileImageUrl
+          ? [profileData.profileImageUrl]
+          : [],
+        type: 'profile'
+      },
+      twitter: {
+        card: 'summary',
+        title: `${profileData.nickname}님의 프로필`,
+        description: `고양이 ${profileData.catCount}마리, 게시물 ${profileData.postCount}개`,
+        images: profileData.profileImageUrl ? [profileData.profileImageUrl] : []
+      }
+    };
+  } catch (error) {
+    return {
+      title: '프로필 | 냥집사',
+      description: '냥집사 유저 프로필'
+    };
+  }
+}
+
+const ProfileIdPage = async ({ params }: PageProps) => {
+  const id = Number(params.id);
+
+  // params validation
+  if (!params.id || isNaN(id)) {
+    throw new Error('유효하지 않은 사용자 ID입니다.');
+  }
 
   const feedReqObj = {
     page: 0,
@@ -23,102 +61,23 @@ const ProfileIdPage = ({ params: { id } }: { params: { id: number } }) => {
     memberId: id
   };
 
-  const {
-    data: othersProfile,
-    isLoading: otherProfileIsLoading,
-    isError: isOthersProfileError,
-    error: othersProfileError
-  } = useQuery({
-    queryKey: ['othersProfile', id],
-    queryFn: () => getClickedUserProfile(id)
-  });
+  try {
+    const [profileData, feedList] = await Promise.all([
+      getClickedUserProfile(id),
+      getOtherUserFeeds(feedReqObj)
+    ]);
 
-  const {
-    data: otherUserFeedList,
-    isLoading: otherFeedIsLoading,
-    isError: isOtherUserFeedListError,
-    error: otherUserFeedListError
-  } = useQuery({
-    queryKey: ['otherUserFeeds', id],
-    queryFn: () => getOtherUserFeeds(feedReqObj)
-  });
-
-  const { toggleLikeFeed, toggleBookmark } = useFeedMutations([
-    'otherUserFeeds'
-  ]);
-
-  if (isOthersProfileError) throw othersProfileError;
-  if (isOtherUserFeedListError) throw otherUserFeedListError;
-
-  return (
-    <>
-      <section className="h-12">
-        <Topbar type="three">
-          <Topbar.Back onClick={() => router.back()} />
-          <Topbar.Title title={othersProfile?.nickname} />
-          <Topbar.Empty />
-        </Topbar>
-      </section>
-      <section className="border-b border-gr-100 bg-gr-white py-4">
-        {otherProfileIsLoading ? (
-          <ProfileSkeleton />
-        ) : (
-          <>
-            <div className="flex justify-center pb-4">
-              <Profile
-                items={[
-                  {
-                    id: id,
-                    imageUrl:
-                      othersProfile?.profileImageUrl ||
-                      DEFAULT_PROFILE_IMAGE_SRC,
-                    style: 'w-[72px] h-[72px]'
-                  }
-                ]}
-                lastLeft="left-[100px]"
-              />
-            </div>
-            <ProfileDetail
-              catCount={othersProfile?.catCount}
-              postCount={othersProfile?.postCount}
-            />
-          </>
-        )}
-      </section>
-      <div className="w-full border-gr-100" />
-      <section className="mx-auto mt-0 max-w-[640px] bg-gr-white">
-        <article className="flex items-center justify-between px-4 py-3">
-          <div className="text-heading-4 text-gr-900">피드</div>
-          <Button
-            onClick={() => router.push(`/profile/${id}/zip`)}
-            className="h-[28px] rounded-16 bg-gr-50 py-2 pl-3 pr-[6px]"
-          >
-            <Button.Text
-              text="모음집 구경하기"
-              className="text-btn-3 text-gr-500"
-            />
-            <Button.Icon alt="right">
-              <RightIcon width={16} height={16} stroke="var(--gr-500)" />
-            </Button.Icon>
-          </Button>
-        </article>
-        <article>
-          {otherFeedIsLoading ? (
-            <ProfileFeedSkeleton />
-          ) : (
-            otherUserFeedList?.map((feed: FeedType) => (
-              <FeedCard
-                key={feed.id}
-                content={feed}
-                goToDetail={() => router.push(`/community/${feed.id}`)}
-                toggleLikeFeed={() => toggleLikeFeed(feed)}
-                toggleBookmark={() => toggleBookmark(feed)}
-              />
-            ))
-          )}
-        </article>
-      </section>
-    </>
-  );
+    return (
+      <ProfileDetailClient
+        id={id}
+        profileData={profileData}
+        feedList={feedList || []}
+      />
+    );
+  } catch (error) {
+    console.error('프로필 로딩 실패:', error);
+    throw error;
+  }
 };
+
 export default ProfileIdPage;

--- a/src/app/profile/[id]/zip/page.tsx
+++ b/src/app/profile/[id]/zip/page.tsx
@@ -1,45 +1,76 @@
-'use client';
-
-import OtherMemberZipModal from '@/components/zip/OtherMemberZipModal';
-import ZipSkeleton from '@/components/zip/ZipSkeleton';
 import { getClickedUserProfile } from '@/services/profile';
-import { useQuery } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { getCatsOnServer } from '@/services/cat';
+import OtherMemberZipClient from '@/components/zip/OtherMemberZipClient';
+import { Metadata } from 'next';
+import { PageResponse } from '@/types/infiniteListType';
+import { CatListObj } from '@/types/cat';
 
-export default function OtherMemeberZipModalPage({
+interface PageProps {
+  params: { id: string };
+}
+
+export async function generateMetadata({
   params
-}: {
-  params: { id: number };
-}) {
-  const router = useRouter();
+}: PageProps): Promise<Metadata> {
+  const id = Number(params.id);
 
-  const {
-    data: othersProfile,
-    isLoading,
-    isError,
-    error
-  } = useQuery({
-    queryKey: ['othersProfile', params.id],
-    queryFn: () => getClickedUserProfile(params.id)
-  });
+  if (!params.id || isNaN(id)) {
+    return {
+      title: '모음집 | 냥집사',
+      description: '냥집사 고양이 모음집'
+    };
+  }
 
-  if (isError) throw error;
+  try {
+    const profileData = await getClickedUserProfile(id);
 
-  return (
-    <>
-      {isLoading ? (
-        <section className="pb-30 h-screen bg-gr-50 px-4 pt-16">
-          <div className="grid grid-cols-2 gap-4 pb-28">
-            <ZipSkeleton />
-          </div>
-        </section>
-      ) : (
-        <OtherMemberZipModal
-          memberId={params.id}
-          onClose={() => router.back()}
-          memberName={othersProfile.nickname}
-        />
-      )}
-    </>
-  );
+    return {
+      title: `${profileData.nickname}님의 모음집 | 냥집사`,
+      description: `${profileData.nickname}님이 돌보는 고양이들을 만나보세요`,
+      openGraph: {
+        title: `${profileData.nickname}님의 모음집`,
+        description: `${profileData.nickname}님이 돌보는 고양이들을 만나보세요`,
+        images: profileData.profileImageUrl
+          ? [profileData.profileImageUrl]
+          : [],
+        type: 'profile'
+      }
+    };
+  } catch (error) {
+    return {
+      title: '모음집 | 냥집사',
+      description: '냥집사 고양이 모음집'
+    };
+  }
+}
+
+export default async function OtherMemberZipModalPage({ params }: PageProps) {
+  const id = Number(params.id);
+
+  // params validation
+  if (!params.id || isNaN(id)) {
+    throw new Error('유효하지 않은 사용자 ID입니다.');
+  }
+
+  try {
+    const [profileData, initialCatsData] = await Promise.all([
+      getClickedUserProfile(id),
+      getCatsOnServer({
+        page: 1,
+        size: 10,
+        memberId: id
+      })
+    ]);
+
+    return (
+      <OtherMemberZipClient
+        memberId={id}
+        memberName={profileData.nickname}
+        initialCatsData={initialCatsData as PageResponse<CatListObj>}
+      />
+    );
+  } catch (error) {
+    console.error('모음집 로딩 실패:', error);
+    throw error;
+  }
 }

--- a/src/app/profile/alarm/page.tsx
+++ b/src/app/profile/alarm/page.tsx
@@ -1,194 +1,44 @@
-'use client';
-import AlarmList from '@/components/profile/AlarmList';
-import Topbar from '@/components/ui/Topbar';
-import { notFound, useRouter } from 'next/navigation';
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger
-} from '@/components/ui/TabsWithLine';
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQueryClient
-} from '@tanstack/react-query';
-import {
-  getCoParentNotifications,
-  getNotifications,
-  readAllNotificationOnServer
-} from '@/services/profile';
-import AlarmEmptyState from '@/components/profile/AlarmEmptyState';
-import AlarmListSkeleton from '@/components/profile/AlarmListSkeleton';
-import { useInView } from 'react-intersection-observer';
-import { useEffect, useMemo } from 'react';
-import { useAtom } from 'jotai';
-import { newNotificationAtom } from '@/store/notificationAtom';
+import { getCoParentNotifications, getNotifications } from '@/services/profile';
+import AlarmPageClient, {
+  AlarmType
+} from '@/components/profile/AlarmPageClient';
+import { PageResponse } from '@/types/infiniteListType';
 
-export interface AlarmType {
-  id: number;
-  title: string;
-  link: string;
-  senderNickname: string;
-  createdAt: string;
-  isRead: boolean;
-  type: 'COMMENT' | 'LIKE' | 'DIARY' | 'COPARENT_REQUEST' | 'COPARENT';
-  isExpired?: boolean;
-  isResponded?: boolean;
-}
+const AlarmPage = async () => {
+  try {
+    const [initialNotifications, initialCoParentNotifications] =
+      await Promise.all([
+        getNotifications({ page: 1, size: 20 }),
+        getCoParentNotifications({ page: 1, size: 20 })
+      ]);
 
-const AlarmPage = () => {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const [_, setHasNewNotification] = useAtom(newNotificationAtom);
-  const { ref: notiRef, inView: notiInView } = useInView();
-  const { ref: coParentRef, inView: coParentInView } = useInView();
-
-  const {
-    data: notifications,
-    isLoading: notiIsLoading,
-    fetchNextPage: fetchNextNotifications,
-    refetch: refetchNotifications,
-    isError: isNotiError,
-    error: notiError
-  } = useInfiniteQuery({
-    queryKey: ['getNotifications'],
-    queryFn: ({ pageParam = 1 }) =>
-      getNotifications({
-        page: pageParam,
-        size: 20
-      }),
-    getNextPageParam: (lastPage, allPages) => {
-      return lastPage.hasNext ? allPages.length + 1 : undefined;
-    },
-    initialPageParam: 1,
-    staleTime: 0
-  });
-  useEffect(() => {
-    if (notiInView) {
-      fetchNextNotifications();
-    }
-  }, [notiInView, fetchNextNotifications]);
-
-  const {
-    data: coParentsNoti,
-    isLoading: coParentIsLoading,
-    fetchNextPage: fetchNextCoparentNofi,
-    refetch: refetchCoParentNotifications,
-    isError: isCoParentNotiError,
-    error: coParentsNotiError
-  } = useInfiniteQuery({
-    queryKey: ['getCoparentsNotifications'],
-    queryFn: ({ pageParam = 1 }) =>
-      getCoParentNotifications({
-        page: pageParam,
-        size: 20
-      }),
-    getNextPageParam: (lastPage, allPages) => {
-      return lastPage.hasNext ? allPages.length + 1 : undefined;
-    },
-    initialPageParam: 1,
-    staleTime: 0
-  });
-  useEffect(() => {
-    if (coParentInView) {
-      fetchNextCoparentNofi();
-    }
-  }, [coParentInView, fetchNextCoparentNofi]);
-
-  const isNotiEmpty = useMemo(() => {
     return (
-      Array.isArray(notifications?.pages?.[0]?.items) &&
-      notifications.pages[0].items.length === 0
+      <AlarmPageClient
+        initialNotifications={initialNotifications as PageResponse<AlarmType>}
+        initialCoParentNotifications={
+          initialCoParentNotifications as PageResponse<AlarmType>
+        }
+      />
     );
-  }, [notifications]);
-
-  const isCoParentEmpty = useMemo(() => {
+  } catch (error) {
+    console.error('알림 로딩 실패:', error);
     return (
-      Array.isArray(coParentsNoti?.pages?.[0]?.items) &&
-      coParentsNoti.pages[0].items.length === 0
+      <AlarmPageClient
+        initialNotifications={{
+          status: 'success',
+          total: 0,
+          hasNext: false,
+          items: []
+        }}
+        initialCoParentNotifications={{
+          status: 'success',
+          total: 0,
+          hasNext: false,
+          items: []
+        }}
+      />
     );
-  }, [coParentsNoti]);
-
-  const readAllNotification = useMutation({
-    mutationFn: () => readAllNotificationOnServer(),
-    onSuccess: (data: any) => {
-      if (data.status === 'OK') {
-        setHasNewNotification(false);
-        refetchNotifications();
-        refetchCoParentNotifications();
-        queryClient.invalidateQueries({ queryKey: ['myProfile'] });
-      }
-    }
-  });
-
-  if (isNotiError) throw notiError;
-  if (isCoParentNotiError) throw coParentsNotiError;
-
-  return (
-    <div className="fixed left-1/2 top-0 z-20 h-screen w-full max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
-      <Topbar type="three">
-        <Topbar.Back onClick={() => router.push('/profile')} />
-        <Topbar.Title title="내 소식" />
-        <Topbar.AllRead onClick={() => readAllNotification.mutate()} />
-      </Topbar>
-      <Tabs
-        defaultValue="notice"
-        className="h-screen items-end bg-gr-white pt-12"
-      >
-        <TabsList className="h-11 items-end">
-          <TabsTrigger value="notice">활동 알림</TabsTrigger>
-          <TabsTrigger value="coParentNotice">공동냥육</TabsTrigger>
-        </TabsList>
-        <TabsContent value="notice" className="mx-auto mt-0 max-w-[640px]">
-          {notiIsLoading ? (
-            <AlarmListSkeleton />
-          ) : isNotiEmpty ? (
-            <div className="flex h-[calc(100vh-90px)] items-center justify-center bg-gr-50">
-              <AlarmEmptyState />
-            </div>
-          ) : (
-            <>
-              {notifications?.pages?.map(page =>
-                page?.items?.map((noti: AlarmType) => (
-                  <div key={noti.id}>
-                    <AlarmList alarm={noti} refetch={refetchNotifications} />
-                  </div>
-                ))
-              )}
-              <div ref={notiRef} className="h-20 bg-transparent" />
-            </>
-          )}
-        </TabsContent>
-        <TabsContent
-          value="coParentNotice"
-          className="mx-auto mt-0 max-w-[640px]"
-        >
-          {coParentIsLoading ? (
-            <AlarmListSkeleton />
-          ) : isCoParentEmpty ? (
-            <div className="flex h-[calc(100vh-90px)] items-center justify-center bg-gr-50">
-              <AlarmEmptyState />
-            </div>
-          ) : (
-            <>
-              {coParentsNoti?.pages?.map(page =>
-                page?.items?.map((noti: AlarmType) => (
-                  <div key={noti.id}>
-                    <AlarmList
-                      alarm={noti}
-                      refetch={refetchCoParentNotifications}
-                    />
-                  </div>
-                ))
-              )}
-              <div ref={coParentRef} className="h-20 bg-transparent" />
-            </>
-          )}
-        </TabsContent>
-      </Tabs>
-    </div>
-  );
+  }
 };
 
 export default AlarmPage;

--- a/src/app/profile/setting/page.tsx
+++ b/src/app/profile/setting/page.tsx
@@ -1,156 +1,19 @@
-'use client';
+import { getPushNotification } from '@/services/push-notification';
+import SettingPageClient from '@/components/setting/SettingPageClient';
 
-import Topbar from '@/components/ui/Topbar';
-import { useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
-import SettingCard from '@/components/setting/SettingCard';
-import { Switch } from '@/components/ui/Switch';
-import { deleteAccountOnServer } from '@/services/signup';
-import { useToast } from '@/components/ui/hooks/useToast';
-import { TermsType } from '@/constants/general';
-import { signOut } from 'next-auth/react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  getPushNotification,
-  togglePushNotificationOnServer
-} from '@/services/push-notification';
-import { getCurrentDateInYYYYMMDD } from '@/utils/common';
-import TermsModal from '@/components/setting/TermsModal';
-import LogoutModal from '@/components/setting/LogoutModal';
-import WithdrawModal from '@/components/setting/WithdrawModal';
-import { useWebView } from '@/hooks/useWebView';
-import { usePushAlarmPermission } from '@/hooks/common/usePushAlarmPermission';
+const SettingPage = async () => {
+  try {
+    const initialPushPermission = await getPushNotification();
 
-const SettingPage = () => {
-  const router = useRouter();
-  const { toast } = useToast();
-  const queryClient = useQueryClient();
-  const { safePostMessage } = useWebView();
-
-  const [logOutModal, setLogOutModal] = useState(false);
-  const [withdrawModal, setWithdrawModal] = useState(false);
-  const [termsModal, setTermsModal] = useState<string>('');
-
-  const {
-    data: pushPermission,
-    isSuccess,
-    isError,
-    error
-  } = useQuery({
-    queryKey: ['getPushNoti'],
-    queryFn: () => getPushNotification(),
-    staleTime: 0
-  });
-
-  const { permission } = usePushAlarmPermission();
-  const togglePushNotification = useMutation({
-    mutationFn: () => togglePushNotificationOnServer(),
-    onSuccess: (data: any) => {
-      if (data.status === 'OK') {
-        queryClient.invalidateQueries({ queryKey: ['getPushNoti'] });
-      }
-    }
-  });
-
-  useEffect(() => {
-    if (
-      isSuccess &&
-      permission !== null &&
-      pushPermission.receivePushNotification !== undefined &&
-      pushPermission.receivePushNotification !== permission
-    ) {
-      toggleSwitch();
-    }
-  }, [permission]);
-
-  const toggleSwitch = () => {
-    togglePushNotification.mutate();
-    toast({
-      description: `${getCurrentDateInYYYYMMDD()} 앱 푸시 수신 동의를 ${permission ? '동의' : '철회'} 했어요`,
-      duration: 2000
-    });
-  };
-
-  const sendMessageToRN = () => {
-    if ((window as any).ReactNativeWebView) {
-      safePostMessage({
-        type: 'OPEN_SETTINGS',
-        timestamp: new Date().toISOString()
-      });
-    } else {
-      alert('앱 설정에서 푸시 알림을 직접 변경해주세요.');
-    }
-  };
-
-  const logOut = async () => {
-    try {
-      await fetch('/api/auth/logout', {
-        method: 'POST',
-        credentials: 'include'
-      });
-      window.location.href = '/signin';
-    } catch (error) {
-      console.error('로그아웃 중 오류:', error);
-      window.location.href = '/signin';
-    }
-  };
-
-  if (isError) throw error;
-
-  return (
-    <>
-      <div className="fixed left-1/2 top-0 z-50 h-full w-full max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
-        <Topbar type="three">
-          <Topbar.Back onClick={() => router.back()} />
-          <Topbar.Title title="설정" />
-          <Topbar.Empty />
-        </Topbar>
-        <div className="mx-auto max-w-[640px]">
-          <section className="flex items-center justify-between pb-4 pl-5 pr-4 pt-16">
-            <div>
-              <h1 className="text-btn-1 text-gr-800">푸시알림</h1>
-              <h1 className="text-body-3 text-gr-400">
-                알림을 꺼도 내 소식에서 확인할 수 있어요
-              </h1>
-            </div>
-            <Switch
-              checked={pushPermission?.receivePushNotification}
-              onCheckedChange={sendMessageToRN}
-            />
-          </section>
-          <section className="h-2 bg-gr-50" />
-          <section>
-            <SettingCard
-              text="이용약관"
-              onClick={() => setTermsModal(TermsType.TERMS_OF_USE)}
-            />
-            <SettingCard
-              text="개인정보 처리방침"
-              onClick={() => setTermsModal(TermsType.PRIVACY_POLICY)}
-            />
-          </section>
-          <section className="h-2 bg-gr-50" />
-          <SettingCard text="로그아웃" onClick={() => setLogOutModal(true)} />
-          <SettingCard text="회원탈퇴" onClick={() => setWithdrawModal(true)} />
-          <section className="pt-20 text-center text-body-3 text-gr-400">
-            <p>문의사항이 있을 경우,</p>
-            <p>meowzzip@gmail.com으로 보내주세요</p>
-          </section>
-        </div>
-        <TermsModal open={termsModal} onClose={() => setTermsModal('')} />
-        <LogoutModal
-          open={logOutModal}
-          onConfirm={logOut}
-          onCancel={() => setLogOutModal(false)}
-        />
-        <WithdrawModal
-          open={withdrawModal}
-          onConfirm={deleteAccountOnServer}
-          onCancel={() => setWithdrawModal(false)}
-        />
-      </div>
-    </>
-  );
+    return <SettingPageClient initialPushPermission={initialPushPermission} />;
+  } catch (error) {
+    console.error('설정 로딩 실패:', error);
+    return (
+      <SettingPageClient
+        initialPushPermission={{ receivePushNotification: false }}
+      />
+    );
+  }
 };
 
 export default SettingPage;

--- a/src/app/zip/[id]/page.tsx
+++ b/src/app/zip/[id]/page.tsx
@@ -1,140 +1,65 @@
-'use client';
+import { getCatDetail } from '@/services/cat';
+import ZipDetailClient from '@/components/zip/ZipDetailClient';
+import { Metadata } from 'next';
 
-import React, { useState } from 'react';
-import ZipDetailDiary from '../../../components/zip/ZipDetailDiary';
-import Topbar from '@/components/ui/Topbar';
-import { useRouter } from 'next/navigation';
-import MoreBtnBottomSheet from '@/components/community/MoreBtnBottomSheet';
-import DetailCardLayout from '@/components/zip/DetailCardLayout';
-import { DiaryObj } from '@/app/diary/diaryType';
-import ZipDetailCoParents from '@/components/zip/ZipDetailCoParents';
-import { CoParent } from '@/types/cat';
-import ZipDetailCatCard from '../../../components/zip/ZipDetailCatCard';
-import CoParentsBottomSheet from '@/components/zip/CoParentsBottomSheet';
-import FindCoParentsModal from '../../../components/zip/FindCoParentsModal';
-import Link from 'next/link';
-import { deleteCat, getCatDetail } from '@/services/cat';
-import { useQuery } from '@tanstack/react-query';
-import { useToast } from '@/components/ui/hooks/useToast';
-import CatDetailSkeleton from '@/components/zip/CatDetailSkeleton';
+interface PageProps {
+  params: { id: string };
+}
 
-const ZipDiaryPage = ({ params: { id } }: { params: { id: number } }) => {
-  const router = useRouter();
+export async function generateMetadata({
+  params
+}: PageProps): Promise<Metadata> {
+  const id = Number(params.id);
 
-  const [editBottomSheet, setEditBottomSheet] = useState(false);
-  const [coParentsBottomSheet, setCoParentsBottomSheet] = useState(false);
-  const [showCoParentsModal, setShowCoParentsModal] = useState(false);
+  if (!params.id || isNaN(id)) {
+    return {
+      title: '고양이 | 냥집사',
+      description: '냥집사 고양이 프로필'
+    };
+  }
 
-  const {
-    data: catDetail,
-    isLoading,
-    isError,
-    error
-  } = useQuery({
-    queryKey: ['catDetail', id],
-    queryFn: () => getCatDetail(id)
-  });
+  try {
+    const catDetail = await getCatDetail(id);
 
-  const { toast } = useToast();
+    return {
+      title: `${catDetail.name} | 냥집사`,
+      description: `${catDetail.age}살, ${catDetail.sex === 'M' ? '남아' : catDetail.sex === 'F' ? '여아' : '성별 미상'}`,
+      openGraph: {
+        title: `${catDetail.name}`,
+        description: `${catDetail.age}살, ${catDetail.sex === 'M' ? '남아' : catDetail.sex === 'F' ? '여아' : '성별 미상'}`,
+        images: catDetail.imageUrl ? [catDetail.imageUrl] : [],
+        type: 'profile'
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${catDetail.name}`,
+        description: `${catDetail.age}살, ${catDetail.sex === 'M' ? '남아' : catDetail.sex === 'F' ? '여아' : '성별 미상'}`,
+        images: catDetail.imageUrl ? [catDetail.imageUrl] : []
+      }
+    };
+  } catch (error) {
+    return {
+      title: '고양이 | 냥집사',
+      description: '냥집사 고양이 프로필'
+    };
+  }
+}
 
-  if (isLoading) return <CatDetailSkeleton />;
-  if (isError) throw error;
+const ZipDiaryPage = async ({ params }: PageProps) => {
+  const id = Number(params.id);
 
-  return (
-    <>
-      <Topbar type="two">
-        <Topbar.Back onClick={() => router.back()} />
-        {catDetail?.isOwner ? (
-          <Topbar.More onClick={() => setEditBottomSheet(true)} />
-        ) : (
-          <Topbar.Empty />
-        )}
-      </Topbar>
-      <section className="mx-auto flex h-screen max-w-[640px] flex-col gap-4 overflow-auto bg-gr-50 px-4 pb-32 pt-[72px]">
-        <article className="rounded-16">
-          <ZipDetailCatCard {...catDetail} />
-        </article>
-        <DetailCardLayout
-          titleObj={{
-            title: '공동집사',
-            onClick: () => {
-              if (catDetail.coParents.length === 0) {
-                toast({
-                  description: '공동집사가 없습니다.',
-                  duration: 1000
-                });
-                return;
-              }
-              setCoParentsBottomSheet(true);
-            }
-          }}
-          btnObj={
-            catDetail.isOwner && {
-              text: '함께할 공동집사 찾기',
-              onClick: () => setShowCoParentsModal(true)
-            }
-          }
-        >
-          <div className="flex pt-2">
-            {catDetail.coParents?.map((coParent: CoParent) => (
-              <ZipDetailCoParents key={coParent.memberId} {...coParent} />
-            ))}
-          </div>
-        </DetailCardLayout>
-        {catDetail.isAccessibleToDiaries && (
-          <DetailCardLayout
-            titleObj={{ title: '일지' }}
-            btnObj={{
-              text: '더보기',
-              onClick: () => router.push(`/diary`)
-            }}
-          >
-            {catDetail.diaries?.slice(0, 3).map((diary: DiaryObj) => (
-              <Link href={`/diary/${diary.id}`} key={diary.id}>
-                <ZipDetailDiary {...diary} />
-              </Link>
-            ))}
-          </DetailCardLayout>
-        )}
-      </section>
-      <MoreBtnBottomSheet
-        type="zip"
-        isVisible={editBottomSheet}
-        setIsVisible={() => setEditBottomSheet(!editBottomSheet)}
-        heightPercent={['50%', '40%']}
-        name={catDetail?.name}
-        memberId={catDetail?.id}
-        onDelete={async () => {
-          try {
-            await deleteCat(catDetail?.id);
-            toast({ description: '삭제되었습니다.', duration: 1000 });
-            router.replace('/zip');
-          } catch (e) {
-            toast({
-              description: '삭제에 실패했습니다. 잠시 후 다시 시도해주세요.',
-              duration: 1500
-            });
-          }
-        }}
-        onEdit={() => {
-          router.push(`/zip/${id}/edit?catId=${catDetail?.id}`);
-          setEditBottomSheet(false);
-        }}
-      />
-      <CoParentsBottomSheet
-        isVisible={coParentsBottomSheet}
-        setIsVisible={() => setCoParentsBottomSheet(!coParentsBottomSheet)}
-        coParents={catDetail.coParents}
-      />
+  if (!params.id || isNaN(id)) {
+    throw new Error('유효하지 않은 고양이 ID입니다.');
+  }
 
-      {showCoParentsModal && (
-        <FindCoParentsModal
-          setShowCoParentsModal={setShowCoParentsModal}
-          catId={catDetail.id}
-        />
-      )}
-    </>
-  );
+  try {
+    const catDetail = await getCatDetail(id);
+
+    return <ZipDetailClient catDetail={catDetail} id={id} />;
+  } catch (error) {
+    console.error('고양이 상세 로딩 실패:', error);
+    throw error;
+  }
 };
 
 export default ZipDiaryPage;

--- a/src/components/community/CommunityContents.tsx
+++ b/src/components/community/CommunityContents.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState, useCallback } from 'react';
 import FeedCard from '../../components/community/FeedCard';
 import MoreBtnBottomSheet from '@/components/community/MoreBtnBottomSheet';
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -79,8 +79,8 @@ const CommunityContents = () => {
   return (
     <div className="mx-auto max-w-[640px] bg-gr-white pb-24">
       {feedList?.pages.map((page, pageIndex) => (
-        <React.Fragment key={pageIndex}>
-          {(page as any)?.items?.map((feed: FeedType) => (
+        <Fragment key={pageIndex}>
+          {(page as any)?.items.map((feed: FeedType) => (
             <div
               key={feed.id}
               className={`transition-all duration-500 ease-out ${
@@ -91,7 +91,9 @@ const CommunityContents = () => {
             >
               <FeedCard
                 content={feed}
-                goToDetail={() => router.push(`/community/${feed.id}`)}
+                goToDetail={() => {
+                  router.push(`/community/${feed.id}`);
+                }}
                 openBottomSheet={() => {
                   setFeed(feed);
                   setEditBottomSheet(true);
@@ -102,7 +104,7 @@ const CommunityContents = () => {
               />
             </div>
           ))}
-        </React.Fragment>
+        </Fragment>
       ))}
       <div ref={ref} className="h-20 bg-transparent" />
       {isFetchingNextPage && <CommunitySkeleton />}
@@ -115,8 +117,10 @@ const CommunityContents = () => {
         memberId={feed?.writerId}
         onDelete={() => feed && handleDeleteWithAnimation(feed)}
         onEdit={() => {
-          if (feed) {
+          if (feed && feed.id) {
             router.push(`/community/write?edit=${feed.id}`);
+          } else {
+            console.warn('피드 ID가 없어 수정할 수 없습니다:', feed);
           }
         }}
         onBlock={() => feed && blockFeed(feed)}

--- a/src/components/community/FeedCard.tsx
+++ b/src/components/community/FeedCard.tsx
@@ -49,6 +49,10 @@ const FeedCard = ({
 
   const clickComment = () => {
     if (variant === 'detail') return;
+    if (!content?.id) {
+      console.warn('피드 ID가 없습니다:', content);
+      return;
+    }
     router.push(`/community/${content.id}`);
   };
 

--- a/src/components/community/detail/Comment.tsx
+++ b/src/components/community/detail/Comment.tsx
@@ -16,10 +16,12 @@ export default function Comment({
 }: {
   onReply: (commentId: number) => void;
   comment: CommentType;
-  setEditBottomSheet: React.Dispatch<React.SetStateAction<boolean>>;
-  setSelectedComment: React.Dispatch<
-    React.SetStateAction<CommentType | undefined>
-  >;
+  setEditBottomSheet:
+    | ((value: boolean) => void)
+    | React.Dispatch<React.SetStateAction<boolean>>;
+  setSelectedComment:
+    | ((comment: CommentType) => void)
+    | React.Dispatch<React.SetStateAction<CommentType | undefined>>;
 }) {
   const router = useRouter();
   return (

--- a/src/components/community/detail/CommentList.tsx
+++ b/src/components/community/detail/CommentList.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Fragment } from 'react';
+import Comment from './Comment';
+import WriteComment from './WriteComment';
+import { CommentType } from '@/types/communityType';
+
+interface CommentListProps {
+  comments: CommentType[];
+  onOpenBottomSheet: (value: boolean) => void;
+  onSelectComment: (comment: CommentType) => void;
+  onReply: (commentId: number) => void;
+  isReplying: boolean;
+  parentCommentId: number | null;
+  feedId: number;
+  onCancelReply: () => void;
+}
+
+const CommentList = ({
+  comments,
+  onOpenBottomSheet,
+  onSelectComment,
+  onReply,
+  isReplying,
+  parentCommentId,
+  feedId,
+  onCancelReply
+}: CommentListProps) => {
+  return (
+    <>
+      {comments.map((comment: CommentType) => (
+        <div key={comment.id} className="py-3">
+          <Comment
+            comment={comment}
+            setEditBottomSheet={onOpenBottomSheet}
+            setSelectedComment={onSelectComment}
+            onReply={onReply}
+          />
+          {isReplying && parentCommentId === comment.id && (
+            <WriteComment
+              feedId={feedId}
+              parentCommentId={parentCommentId}
+              onCancel={onCancelReply}
+            />
+          )}
+          {comment.replies?.map((reply: CommentType) => (
+            <Fragment key={reply.id}>
+              {isReplying && parentCommentId === reply.id && (
+                <WriteComment
+                  feedId={feedId}
+                  parentCommentId={parentCommentId}
+                  onCancel={onCancelReply}
+                />
+              )}
+            </Fragment>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default CommentList;

--- a/src/components/community/detail/CommunityDetailClient.tsx
+++ b/src/components/community/detail/CommunityDetailClient.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import WriteComment from './WriteComment';
+import MoreBtnBottomSheet from '../MoreBtnBottomSheet';
+import FeedWriteModal from '../FeedWriteModal';
+import Topbar from '@/components/ui/Topbar';
+import useFeedMutations from '@/hooks/community/useFeedMutations';
+import useCommentMutation from '@/hooks/community/useCommentMutation';
+import { FeedType, CommentType } from '@/types/communityType';
+import FeedDetailContent from './FeedDetailContent';
+import CommentList from './CommentList';
+
+interface CommunityDetailClientProps {
+  feedDetail: FeedType;
+  comments: CommentType[];
+  slug: number;
+}
+
+const CommunityDetailClient = ({
+  feedDetail: initialFeed,
+  comments: initialComments,
+  slug
+}: CommunityDetailClientProps) => {
+  const router = useRouter();
+  const bottomSheetRef = useRef<HTMLDivElement>(null);
+  const [, setBottomSheetHeight] = useState<number>(0);
+
+  const [editBottomSheet, setEditBottomSheet] = useState(false);
+  const [showWriteModal, setShowWriteModal] = useState(false);
+  const [selectedComment, setSelectedComment] = useState<CommentType>();
+  const [parentCommentId, setParentCommentId] = useState<number | null>(null);
+  const [isReplying, setIsReplying] = useState(false);
+
+  const { deleteFeed, blockFeed, reportFeed, toggleLikeFeed, toggleBookmark } =
+    useFeedMutations(['feeds', 'feedDetail']);
+
+  const { blockComment, reportComment, deleteComment } = useCommentMutation();
+
+  useEffect(() => {
+    if (bottomSheetRef.current) {
+      const height = bottomSheetRef.current.scrollHeight;
+      setBottomSheetHeight(height);
+    }
+  }, [editBottomSheet]);
+
+  const handleReply = useCallback((commentId: number) => {
+    setParentCommentId(commentId);
+    setIsReplying(true);
+  }, []);
+
+  const handleCancelReply = useCallback(() => {
+    setParentCommentId(null);
+    setIsReplying(false);
+  }, []);
+
+  return (
+    <div className="fixed top-0 z-50 mx-auto flex h-app w-full max-w-[640px] flex-col bg-gr-white">
+      <Topbar type="three" className="flex-none">
+        <Topbar.Back onClick={() => router.back()} />
+        <Topbar.Title title="피드" />
+        <Topbar.Empty />
+      </Topbar>
+      <div className="flex-1 overflow-y-auto">
+        <div className="pb-24 pt-12">
+          <FeedDetailContent
+            feedDetail={initialFeed}
+            onOpenBottomSheet={() => setEditBottomSheet(true)}
+            onToggleLike={() => toggleLikeFeed(initialFeed)}
+            onToggleBookmark={() => toggleBookmark(initialFeed)}
+          />
+          {initialComments.length === 0 ? (
+            <p className="py-8 text-center text-sm text-gr-300">
+              아직 댓글이 없어요
+              <br />
+              가장 먼저 댓글을 남겨보세요.
+            </p>
+          ) : (
+            <CommentList
+              comments={initialComments}
+              onOpenBottomSheet={setEditBottomSheet}
+              onSelectComment={setSelectedComment}
+              onReply={handleReply}
+              isReplying={isReplying}
+              parentCommentId={parentCommentId}
+              feedId={initialFeed.id}
+              onCancelReply={handleCancelReply}
+            />
+          )}
+        </div>
+      </div>
+      <div className="z-[60] flex-none border-t border-gr-100 bg-gr-white shadow-sm">
+        {!isReplying && <WriteComment feedId={initialFeed.id} />}
+      </div>
+      {showWriteModal && (
+        <FeedWriteModal
+          onClose={() => setShowWriteModal(false)}
+          feedDetail={initialFeed}
+        />
+      )}
+      <MoreBtnBottomSheet
+        type={selectedComment ? 'comment' : 'feed'}
+        isVisible={editBottomSheet}
+        setIsVisible={() => setEditBottomSheet(!editBottomSheet)}
+        heightPercent={['50%', '60%']}
+        name={
+          selectedComment
+            ? selectedComment?.memberNickname
+            : initialFeed?.writerNickname
+        }
+        memberId={
+          selectedComment ? selectedComment?.memberId : initialFeed?.writerId
+        }
+        onDelete={() => {
+          if (selectedComment) {
+            deleteComment({
+              postId: initialFeed.id,
+              commentId: selectedComment.id
+            });
+          } else {
+            deleteFeed(initialFeed);
+          }
+        }}
+        onEdit={() => {
+          if (!selectedComment) {
+            setShowWriteModal(true);
+          }
+        }}
+        onBlock={() => {
+          if (selectedComment) {
+            blockComment(initialFeed.id);
+          } else {
+            blockFeed(initialFeed);
+          }
+        }}
+        onReport={() => {
+          if (selectedComment) {
+            reportComment(initialFeed.id, selectedComment.id);
+          } else {
+            reportFeed(initialFeed);
+          }
+        }}
+        showWriteModal={
+          selectedComment ? undefined : () => setShowWriteModal(true)
+        }
+      />
+    </div>
+  );
+};
+
+export default CommunityDetailClient;

--- a/src/components/community/detail/FeedDetailContent.tsx
+++ b/src/components/community/detail/FeedDetailContent.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import UserArea from '../feed/UserArea';
+import Carousel from '@/components/ui/Carousel';
+import ButtonArea from '@/components/community/feed/ButtonArea';
+import { FeedType } from '@/types/communityType';
+import { DEFAULT_PROFILE_IMAGE_SRC } from '@/constants/general';
+
+interface FeedDetailContentProps {
+  feedDetail: FeedType;
+  onOpenBottomSheet: () => void;
+  onToggleLike: () => void;
+  onToggleBookmark: () => void;
+}
+
+const FeedDetailContent = ({
+  feedDetail,
+  onOpenBottomSheet,
+  onToggleLike,
+  onToggleBookmark
+}: FeedDetailContentProps) => {
+  const [showMore, setShowMore] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setIsClamped(
+        contentRef.current.scrollHeight > contentRef.current.clientHeight
+      );
+    }
+  }, [feedDetail?.content]);
+
+  const toggleContent = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    e.stopPropagation();
+    setShowMore(!showMore);
+  };
+
+  return (
+    <div className="border-b border-gr-100 bg-gr-white px-4 pt-4">
+      <UserArea
+        writerId={feedDetail?.writerId}
+        nickname={feedDetail?.writerNickname}
+        profile={feedDetail?.writerProfileImage || DEFAULT_PROFILE_IMAGE_SRC}
+        createdAt={feedDetail?.createdAt}
+        onClick={onOpenBottomSheet}
+      />
+      <section className="flex flex-col items-start gap-1">
+        <p
+          ref={contentRef}
+          className={`w-full whitespace-pre-line pt-4 text-body-3 text-gr-black ${
+            showMore ? 'line-clamp-none' : 'line-clamp-3'
+          }`}
+        >
+          {feedDetail?.content}
+        </p>
+        {isClamped && (
+          <button
+            className="text-body-3 text-gr-300"
+            onClick={e => toggleContent(e)}
+          >
+            {showMore ? '간략히' : '더보기'}
+          </button>
+        )}
+      </section>
+      {feedDetail?.images && feedDetail?.images?.length > 0 && (
+        <section className="flex h-[300px] gap-2 pt-4">
+          <Carousel images={feedDetail.images} style="rounded-b-lg" />
+        </section>
+      )}
+      <ButtonArea
+        like={feedDetail?.likeCount}
+        isLiked={feedDetail?.isLiked}
+        isBookmarked={feedDetail?.isBookmarked}
+        comment={feedDetail?.commentCount}
+        toggleLike={onToggleLike}
+        toggleBookmark={onToggleBookmark}
+        clickComment={() => {}}
+      />
+    </div>
+  );
+};
+
+export default FeedDetailContent;

--- a/src/components/diary/DiaryDetailClient.tsx
+++ b/src/components/diary/DiaryDetailClient.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import Topbar from '@/components/ui/Topbar';
+import MoreBtnBottomSheet from '@/components/community/MoreBtnBottomSheet';
+import { deleteDiaryOnServer } from '@/services/diary';
+import DiaryDetailContent from './DiaryDetailContent';
+
+interface DiaryDetailClientProps {
+  diaryDetail: any;
+  id: number;
+}
+
+const DiaryDetailClient = ({ diaryDetail, id }: DiaryDetailClientProps) => {
+  const router = useRouter();
+  const [editBottomSheet, setEditBottomSheet] = useState(false);
+
+  const deleteDiaryMutation = useMutation({
+    mutationFn: (id: number) => deleteDiaryOnServer(id),
+    onSuccess: (response: any) => {
+      if (response.status === 'OK') {
+        router.push('/diary');
+      } else {
+        console.error('일지 삭제 중 오류:', response.message);
+      }
+    },
+    onError: (error: any) => {
+      console.error('일지 삭제 중 오류:', error);
+    }
+  });
+
+  const deleteDiary = useCallback(() => {
+    deleteDiaryMutation.mutate(id);
+  }, [deleteDiaryMutation, id]);
+
+  return (
+    <div className="relative mx-auto">
+      <div className="fixed left-1/2 top-0 z-50 h-screen w-screen max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
+        <Topbar type="two">
+          <Topbar.Back onClick={() => router.back()} />
+          <Topbar.Title title={diaryDetail?.caredDate} />
+          <Topbar.More onClick={() => setEditBottomSheet(true)} />
+        </Topbar>
+        <DiaryDetailContent diaryDetail={diaryDetail} />
+        <MoreBtnBottomSheet
+          type="diary"
+          isVisible={editBottomSheet}
+          setIsVisible={() => setEditBottomSheet(!editBottomSheet)}
+          heightPercent={['50%', '40%']}
+          name={diaryDetail?.memberNickname}
+          memberId={diaryDetail?.memberId}
+          onDelete={deleteDiary}
+          onEdit={() => router.push(`/diary/${id}/edit`)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DiaryDetailClient;

--- a/src/components/diary/DiaryDetailContent.tsx
+++ b/src/components/diary/DiaryDetailContent.tsx
@@ -1,0 +1,75 @@
+import Carousel from '@/components/ui/Carousel';
+import Label from '@/components/ui/Label';
+import { CatType } from '@/types/cat';
+import Image from 'next/image';
+
+interface DiaryDetailContentProps {
+  diaryDetail: any;
+}
+
+const DiaryDetailContent = ({ diaryDetail }: DiaryDetailContentProps) => {
+  return (
+    <div className="m-auto max-w-[640px]">
+      <section className="flex flex-col gap-4 border-b border-gr-100 px-4 pb-8 pt-12">
+        <h5 className="text-end text-body-4 text-gr-500">
+          {diaryDetail?.memberNickname} • {diaryDetail?.caredTime}
+        </h5>
+        {diaryDetail?.images.length > 0 && (
+          <div className="flex h-[300px] w-full">
+            <Carousel images={diaryDetail?.images} style="rounded-16" />
+          </div>
+        )}
+        <h4 className="w-full whitespace-pre-line text-body-3 text-gr-black">
+          {diaryDetail?.content}
+        </h4>
+        <article className="mb-2 flex items-center justify-start gap-1">
+          {diaryDetail?.isFeed && (
+            <Label.Text
+              content="🐟 사료"
+              className="rounded-md bg-gr-50 px-[6px] pb-1 pt-[5px]"
+            />
+          )}
+          {diaryDetail?.isGivenWater && (
+            <Label.Text
+              content="💧 물"
+              className="rounded-md bg-gr-50 px-[6px] pb-1 pt-[5px]"
+            />
+          )}
+        </article>
+      </section>
+      <section className="px-4 pb-[120px] pt-4">
+        <h3 className="py-3 text-heading-5 text-gr-900">
+          태그된 고양이
+          <span className="pl-1 text-pr-500">
+            {diaryDetail?.taggedCats?.length}
+          </span>
+        </h3>
+        {diaryDetail?.taggedCats?.map((cat: CatType) => (
+          <article key={cat.id} className="flex items-center gap-4 py-2">
+            <Image
+              src={cat.imageUrl}
+              alt="cat-image"
+              width={48}
+              height={48}
+              className="h-12 w-12 rounded-full"
+            />
+            <div className="flex items-center gap-2">
+              <h4 className="text-body-3 text-gr-900">{cat.name}</h4>
+              <Image
+                src={`/images/icons/gender-${cat.sex}.svg`}
+                alt="cat-gender"
+                width={16}
+                height={16}
+                className={`rounded-full ${
+                  cat.sex === 'F' ? 'bg-[#FFF2F1]' : 'bg-[#ECF5FF]'
+                }`}
+              />
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+};
+
+export default DiaryDetailContent;

--- a/src/components/profile/AlarmList.tsx
+++ b/src/components/profile/AlarmList.tsx
@@ -9,7 +9,7 @@ import {
   validateNotification
 } from '@/services/profile';
 import { useMutation } from '@tanstack/react-query';
-import { AlarmType } from '@/app/profile/alarm/page';
+import { AlarmType } from './AlarmPageClient';
 
 interface AlarmListProps {
   alarm: AlarmType;

--- a/src/components/profile/AlarmPageClient.tsx
+++ b/src/components/profile/AlarmPageClient.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger
+} from '@/components/ui/TabsWithLine';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient
+} from '@tanstack/react-query';
+import {
+  getCoParentNotifications,
+  getNotifications,
+  readAllNotificationOnServer
+} from '@/services/profile';
+import AlarmEmptyState from './AlarmEmptyState';
+import AlarmListSkeleton from './AlarmListSkeleton';
+import { useInView } from 'react-intersection-observer';
+import { useEffect, useMemo } from 'react';
+import { useAtom } from 'jotai';
+import { newNotificationAtom } from '@/store/notificationAtom';
+import Topbar from '@/components/ui/Topbar';
+import AlarmList from './AlarmList';
+import { PageResponse } from '@/types/infiniteListType';
+
+export type AlarmType = {
+  id: number;
+  title: string;
+  link: string;
+  senderNickname: string;
+  createdAt: string;
+  isRead: boolean;
+  type: 'COMMENT' | 'LIKE' | 'DIARY' | 'COPARENT_REQUEST' | 'COPARENT';
+  isExpired?: boolean;
+  isResponded?: boolean;
+};
+
+interface AlarmPageClientProps {
+  initialNotifications: PageResponse<AlarmType>;
+  initialCoParentNotifications: PageResponse<AlarmType>;
+}
+
+const AlarmPageClient = ({
+  initialNotifications,
+  initialCoParentNotifications
+}: AlarmPageClientProps) => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [_, setHasNewNotification] = useAtom(newNotificationAtom);
+  const { ref: notiRef, inView: notiInView } = useInView();
+  const { ref: coParentRef, inView: coParentInView } = useInView();
+
+  useEffect(() => {
+    queryClient.setQueryData(['getNotifications'], {
+      pages: [initialNotifications],
+      pageParams: [1]
+    });
+    queryClient.setQueryData(['getCoparentsNotifications'], {
+      pages: [initialCoParentNotifications],
+      pageParams: [1]
+    });
+  }, [initialNotifications, initialCoParentNotifications, queryClient]);
+
+  const {
+    data: notifications,
+    isLoading: notiIsLoading,
+    fetchNextPage: fetchNextNotifications,
+    refetch: refetchNotifications,
+    isError: isNotiError,
+    error: notiError
+  } = useInfiniteQuery({
+    queryKey: ['getNotifications'],
+    queryFn: ({ pageParam = 1 }) =>
+      getNotifications({
+        page: pageParam,
+        size: 20
+      }),
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.hasNext ? allPages.length + 1 : undefined;
+    },
+    initialPageParam: 1,
+    staleTime: 0
+  });
+
+  useEffect(() => {
+    if (notiInView) {
+      fetchNextNotifications();
+    }
+  }, [notiInView, fetchNextNotifications]);
+
+  const {
+    data: coParentsNoti,
+    isLoading: coParentIsLoading,
+    fetchNextPage: fetchNextCoparentNofi,
+    refetch: refetchCoParentNotifications,
+    isError: isCoParentNotiError,
+    error: coParentsNotiError
+  } = useInfiniteQuery({
+    queryKey: ['getCoparentsNotifications'],
+    queryFn: ({ pageParam = 1 }) =>
+      getCoParentNotifications({
+        page: pageParam,
+        size: 20
+      }),
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.hasNext ? allPages.length + 1 : undefined;
+    },
+    initialPageParam: 1,
+    staleTime: 0
+  });
+
+  useEffect(() => {
+    if (coParentInView) {
+      fetchNextCoparentNofi();
+    }
+  }, [coParentInView, fetchNextCoparentNofi]);
+
+  const isNotiEmpty = useMemo(() => {
+    return (
+      Array.isArray(notifications?.pages?.[0]?.items) &&
+      notifications.pages[0].items.length === 0
+    );
+  }, [notifications]);
+
+  const isCoParentEmpty = useMemo(() => {
+    return (
+      Array.isArray(coParentsNoti?.pages?.[0]?.items) &&
+      coParentsNoti.pages[0].items.length === 0
+    );
+  }, [coParentsNoti]);
+
+  const readAllNotification = useMutation({
+    mutationFn: () => readAllNotificationOnServer(),
+    onSuccess: (data: any) => {
+      if (data.status === 'OK') {
+        setHasNewNotification(false);
+        refetchNotifications();
+        refetchCoParentNotifications();
+        queryClient.invalidateQueries({ queryKey: ['myProfile'] });
+      }
+    }
+  });
+
+  if (isNotiError) throw notiError;
+  if (isCoParentNotiError) throw coParentsNotiError;
+
+  return (
+    <div className="fixed left-1/2 top-0 z-20 h-screen w-full max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
+      <Topbar type="three">
+        <Topbar.Back onClick={() => router.push('/profile')} />
+        <Topbar.Title title="내 소식" />
+        <Topbar.AllRead onClick={() => readAllNotification.mutate()} />
+      </Topbar>
+      <Tabs
+        defaultValue="notice"
+        className="h-screen items-end bg-gr-white pt-12"
+      >
+        <TabsList className="h-11 items-end">
+          <TabsTrigger value="notice">활동 알림</TabsTrigger>
+          <TabsTrigger value="coParentNotice">공동냥육</TabsTrigger>
+        </TabsList>
+        <TabsContent value="notice" className="mx-auto mt-0 max-w-[640px]">
+          {notiIsLoading ? (
+            <AlarmListSkeleton />
+          ) : isNotiEmpty ? (
+            <div className="flex h-[calc(100vh-90px)] items-center justify-center bg-gr-50">
+              <AlarmEmptyState />
+            </div>
+          ) : (
+            <>
+              {notifications?.pages?.map(page =>
+                page?.items?.map((noti: AlarmType) => (
+                  <div key={noti.id}>
+                    <AlarmList alarm={noti} refetch={refetchNotifications} />
+                  </div>
+                ))
+              )}
+              <div ref={notiRef} className="h-20 bg-transparent" />
+            </>
+          )}
+        </TabsContent>
+        <TabsContent
+          value="coParentNotice"
+          className="mx-auto mt-0 max-w-[640px]"
+        >
+          {coParentIsLoading ? (
+            <AlarmListSkeleton />
+          ) : isCoParentEmpty ? (
+            <div className="flex h-[calc(100vh-90px)] items-center justify-center bg-gr-50">
+              <AlarmEmptyState />
+            </div>
+          ) : (
+            <>
+              {coParentsNoti?.pages?.map(page =>
+                page?.items?.map((noti: AlarmType) => (
+                  <div key={noti.id}>
+                    <AlarmList
+                      alarm={noti}
+                      refetch={refetchCoParentNotifications}
+                    />
+                  </div>
+                ))
+              )}
+              <div ref={coParentRef} className="h-20 bg-transparent" />
+            </>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default AlarmPageClient;

--- a/src/components/profile/ProfileContent.tsx
+++ b/src/components/profile/ProfileContent.tsx
@@ -1,0 +1,37 @@
+import Profile from '@/components/ui/Profile';
+import ProfileDetail from './ProfileDetail';
+import { DEFAULT_PROFILE_IMAGE_SRC } from '@/constants/general';
+
+interface ProfileContentProps {
+  id: number;
+  profileImageUrl: string;
+  catCount: number;
+  postCount: number;
+}
+
+const ProfileContent = ({
+  id,
+  profileImageUrl,
+  catCount,
+  postCount
+}: ProfileContentProps) => {
+  return (
+    <section className="border-b border-gr-100 bg-gr-white py-4">
+      <div className="flex justify-center pb-4">
+        <Profile
+          items={[
+            {
+              id: id,
+              imageUrl: profileImageUrl || DEFAULT_PROFILE_IMAGE_SRC,
+              style: 'w-[72px] h-[72px]'
+            }
+          ]}
+          lastLeft="left-[100px]"
+        />
+      </div>
+      <ProfileDetail catCount={catCount} postCount={postCount} />
+    </section>
+  );
+};
+
+export default ProfileContent;

--- a/src/components/profile/ProfileDetailClient.tsx
+++ b/src/components/profile/ProfileDetailClient.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Topbar from '@/components/ui/Topbar';
+import Button from '@/components/ui/Button';
+import useFeedMutations from '@/hooks/community/useFeedMutations';
+import ProfileContent from './ProfileContent';
+import ProfileFeedList from './ProfileFeedList';
+import RightIcon from '../../../public/images/icons/right.svg';
+
+interface ProfileDetailClientProps {
+  id: number;
+  profileData: {
+    nickname: string;
+    profileImageUrl: string;
+    catCount: number;
+    postCount: number;
+  };
+  feedList: any[];
+}
+
+const ProfileDetailClient = ({
+  id,
+  profileData,
+  feedList
+}: ProfileDetailClientProps) => {
+  const router = useRouter();
+  const { toggleLikeFeed, toggleBookmark } = useFeedMutations([
+    'otherUserFeeds'
+  ]);
+
+  return (
+    <>
+      <section className="h-12">
+        <Topbar type="three">
+          <Topbar.Back onClick={() => router.back()} />
+          <Topbar.Title title={profileData?.nickname} />
+          <Topbar.Empty />
+        </Topbar>
+      </section>
+      <ProfileContent
+        id={id}
+        profileImageUrl={profileData.profileImageUrl}
+        catCount={profileData.catCount}
+        postCount={profileData.postCount}
+      />
+      <div className="w-full border-gr-100" />
+      <section className="mx-auto mt-0 max-w-[640px] bg-gr-white">
+        <article className="flex items-center justify-between px-4 py-3">
+          <div className="text-heading-4 text-gr-900">피드</div>
+          <Button
+            onClick={() => router.push(`/profile/${id}/zip`)}
+            className="h-[28px] rounded-16 bg-gr-50 py-2 pl-3 pr-[6px]"
+          >
+            <Button.Text
+              text="모음집 구경하기"
+              className="text-btn-3 text-gr-500"
+            />
+            <Button.Icon alt="right">
+              <RightIcon width={16} height={16} stroke="var(--gr-500)" />
+            </Button.Icon>
+          </Button>
+        </article>
+        <ProfileFeedList
+          feedList={feedList}
+          onToggleLike={toggleLikeFeed}
+          onToggleBookmark={toggleBookmark}
+        />
+      </section>
+    </>
+  );
+};
+
+export default ProfileDetailClient;

--- a/src/components/profile/ProfileFeedList.tsx
+++ b/src/components/profile/ProfileFeedList.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import FeedCard from '@/components/community/FeedCard';
+import { FeedType } from '@/types/communityType';
+
+interface ProfileFeedListProps {
+  feedList: FeedType[];
+  onToggleLike: (feed: FeedType) => void;
+  onToggleBookmark: (feed: FeedType) => void;
+}
+
+const ProfileFeedList = ({
+  feedList,
+  onToggleLike,
+  onToggleBookmark
+}: ProfileFeedListProps) => {
+  const router = useRouter();
+
+  return (
+    <article>
+      {feedList.map((feed: FeedType) => (
+        <FeedCard
+          key={feed.id}
+          content={feed}
+          goToDetail={() => {
+            router.push(`/community/${feed.id}`);
+          }}
+          toggleLikeFeed={() => onToggleLike(feed)}
+          toggleBookmark={() => onToggleBookmark(feed)}
+        />
+      ))}
+    </article>
+  );
+};
+
+export default ProfileFeedList;

--- a/src/components/setting/SettingPageClient.tsx
+++ b/src/components/setting/SettingPageClient.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useState, useCallback } from 'react';
+import SettingCard from './SettingCard';
+import { Switch } from '@/components/ui/Switch';
+import { deleteAccountOnServer } from '@/services/signup';
+import { useToast } from '@/components/ui/hooks/useToast';
+import { TermsType } from '@/constants/general';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getPushNotification,
+  togglePushNotificationOnServer
+} from '@/services/push-notification';
+import { getCurrentDateInYYYYMMDD } from '@/utils/common';
+import TermsModal from './TermsModal';
+import LogoutModal from './LogoutModal';
+import WithdrawModal from './WithdrawModal';
+import { useWebView } from '@/hooks/useWebView';
+import { usePushAlarmPermission } from '@/hooks/common/usePushAlarmPermission';
+import Topbar from '@/components/ui/Topbar';
+
+interface SettingPageClientProps {
+  initialPushPermission: {
+    receivePushNotification: boolean;
+  };
+}
+
+const SettingPageClient = ({
+  initialPushPermission
+}: SettingPageClientProps) => {
+  const router = useRouter();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { safePostMessage } = useWebView();
+
+  const [logOutModal, setLogOutModal] = useState(false);
+  const [withdrawModal, setWithdrawModal] = useState(false);
+  const [termsModal, setTermsModal] = useState<string>('');
+
+  useEffect(() => {
+    queryClient.setQueryData(['getPushNoti'], initialPushPermission);
+  }, [initialPushPermission, queryClient]);
+
+  const {
+    data: pushPermission,
+    isSuccess,
+    isError,
+    error
+  } = useQuery({
+    queryKey: ['getPushNoti'],
+    queryFn: () => getPushNotification(),
+    staleTime: 0
+  });
+
+  const { permission } = usePushAlarmPermission();
+  const togglePushNotification = useMutation({
+    mutationFn: () => togglePushNotificationOnServer(),
+    onSuccess: (data: any) => {
+      if (data.status === 'OK') {
+        queryClient.invalidateQueries({ queryKey: ['getPushNoti'] });
+      }
+    }
+  });
+
+  const toggleSwitch = useCallback(() => {
+    togglePushNotification.mutate();
+    toast({
+      description: `${getCurrentDateInYYYYMMDD()} 앱 푸시 수신 동의를 ${permission ? '동의' : '철회'} 했어요`,
+      duration: 2000
+    });
+  }, [togglePushNotification, toast, permission]);
+
+  useEffect(() => {
+    if (
+      isSuccess &&
+      permission !== null &&
+      pushPermission.receivePushNotification !== undefined &&
+      pushPermission.receivePushNotification !== permission
+    ) {
+      toggleSwitch();
+    }
+  }, [permission, isSuccess, pushPermission, toggleSwitch]);
+
+  const sendMessageToRN = useCallback(() => {
+    if ((window as any).ReactNativeWebView) {
+      safePostMessage({
+        type: 'OPEN_SETTINGS',
+        timestamp: new Date().toISOString()
+      });
+    } else {
+      alert('앱 설정에서 푸시 알림을 직접 변경해주세요.');
+    }
+  }, [safePostMessage]);
+
+  const logOut = useCallback(async () => {
+    try {
+      await fetch('/api/auth/logout', {
+        method: 'POST',
+        credentials: 'include'
+      });
+      window.location.href = '/signin';
+    } catch (error) {
+      console.error('로그아웃 중 오류:', error);
+      window.location.href = '/signin';
+    }
+  }, []);
+
+  if (isError) throw error;
+
+  return (
+    <>
+      <div className="fixed left-1/2 top-0 z-50 h-full w-full max-w-[640px] -translate-x-1/2 overflow-y-auto bg-gr-white">
+        <Topbar type="three">
+          <Topbar.Back onClick={() => router.back()} />
+          <Topbar.Title title="설정" />
+          <Topbar.Empty />
+        </Topbar>
+        <div className="mx-auto max-w-[640px]">
+          <section className="flex items-center justify-between pb-4 pl-5 pr-4 pt-16">
+            <div>
+              <h1 className="text-btn-1 text-gr-800">푸시알림</h1>
+              <h1 className="text-body-3 text-gr-400">
+                알림을 꺼도 내 소식에서 확인할 수 있어요
+              </h1>
+            </div>
+            <Switch
+              checked={pushPermission?.receivePushNotification}
+              onCheckedChange={sendMessageToRN}
+            />
+          </section>
+          <section className="h-2 bg-gr-50" />
+          <section>
+            <SettingCard
+              text="이용약관"
+              onClick={() => setTermsModal(TermsType.TERMS_OF_USE)}
+            />
+            <SettingCard
+              text="개인정보 처리방침"
+              onClick={() => setTermsModal(TermsType.PRIVACY_POLICY)}
+            />
+          </section>
+          <section className="h-2 bg-gr-50" />
+          <SettingCard text="로그아웃" onClick={() => setLogOutModal(true)} />
+          <SettingCard text="회원탈퇴" onClick={() => setWithdrawModal(true)} />
+          <section className="pt-20 text-center text-body-3 text-gr-400">
+            <p>문의사항이 있을 경우,</p>
+            <p>meowzzip@gmail.com으로 보내주세요</p>
+          </section>
+        </div>
+        <TermsModal open={termsModal} onClose={() => setTermsModal('')} />
+        <LogoutModal
+          open={logOutModal}
+          onConfirm={logOut}
+          onCancel={() => setLogOutModal(false)}
+        />
+        <WithdrawModal
+          open={withdrawModal}
+          onConfirm={deleteAccountOnServer}
+          onCancel={() => setWithdrawModal(false)}
+        />
+      </div>
+    </>
+  );
+};
+
+export default SettingPageClient;

--- a/src/components/zip/OtherMemberZipClient.tsx
+++ b/src/components/zip/OtherMemberZipClient.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { CatListObj } from '@/types/cat';
+import { useRouter } from 'next/navigation';
+import ZipCard from '@/components/zip/ZipCard';
+import { useInView } from 'react-intersection-observer';
+import { useEffect, useCallback } from 'react';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { getCatsOnServer } from '@/services/cat';
+import Topbar from '@/components/ui/Topbar';
+import { PageResponse } from '@/types/infiniteListType';
+
+interface OtherMemberZipClientProps {
+  memberId: number;
+  memberName: string;
+  initialCatsData: PageResponse<CatListObj>;
+}
+
+const OtherMemberZipClient = ({
+  memberId,
+  memberName,
+  initialCatsData
+}: OtherMemberZipClientProps) => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    queryClient.setQueryData(['getCats', memberId], {
+      pages: [initialCatsData],
+      pageParams: [1]
+    });
+  }, [initialCatsData, memberId, queryClient]);
+
+  const {
+    data: catList,
+    fetchNextPage,
+    isLoading,
+    isError,
+    error
+  } = useInfiniteQuery({
+    queryKey: ['getCats', memberId],
+    queryFn: ({ pageParam = 1 }) =>
+      getCatsOnServer({
+        page: pageParam,
+        size: 10,
+        memberId
+      }),
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.hasNext ? allPages.length + 1 : undefined;
+    },
+    initialPageParam: 1,
+    staleTime: 0
+  });
+
+  useEffect(() => {
+    if (inView) {
+      fetchNextPage();
+    }
+  }, [inView, fetchNextPage]);
+
+  const openDetailModal = useCallback(
+    (item: CatListObj) => {
+      router.push(`/zip/${item.id}`);
+    },
+    [router]
+  );
+
+  if (isError) throw error;
+
+  return (
+    <div className="fixed left-0 top-0 z-[50] h-screen w-full overflow-y-auto bg-gr-50">
+      <Topbar type="three">
+        <Topbar.Back onClick={() => router.back()} />
+        <Topbar.Title title={`${memberName} 모음집`} />
+        <Topbar.Empty />
+      </Topbar>
+      <section className="pb-30 h-screen bg-gr-50 px-4 pt-16">
+        <div className="grid grid-cols-2 gap-4 pb-28">
+          {catList?.pages?.map(page =>
+            page?.items?.map((cat: CatListObj) => (
+              <ZipCard
+                key={cat.id}
+                {...cat}
+                onClick={() => openDetailModal(cat)}
+              />
+            ))
+          )}
+          {/* 무한 스크롤 감지 영역 */}
+          <div ref={ref} className="h-20 bg-transparent" />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default OtherMemberZipClient;

--- a/src/components/zip/ZipDetailClient.tsx
+++ b/src/components/zip/ZipDetailClient.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import Topbar from '@/components/ui/Topbar';
+import MoreBtnBottomSheet from '@/components/community/MoreBtnBottomSheet';
+import { deleteCat } from '@/services/cat';
+import { useToast } from '@/components/ui/hooks/useToast';
+import ZipDetailContent from './ZipDetailContent';
+import CoParentsBottomSheet from './CoParentsBottomSheet';
+import FindCoParentsModal from './FindCoParentsModal';
+
+interface ZipDetailClientProps {
+  catDetail: any;
+  id: number;
+}
+
+const ZipDetailClient = ({ catDetail, id }: ZipDetailClientProps) => {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [editBottomSheet, setEditBottomSheet] = useState(false);
+  const [coParentsBottomSheet, setCoParentsBottomSheet] = useState(false);
+  const [showCoParentsModal, setShowCoParentsModal] = useState(false);
+
+  const handleCoParentsClick = useCallback(() => {
+    if (catDetail.coParents.length === 0) {
+      toast({
+        description: '공동집사가 없습니다.',
+        duration: 1000
+      });
+      return;
+    }
+    setCoParentsBottomSheet(true);
+  }, [catDetail.coParents, toast]);
+
+  const handleDelete = useCallback(async () => {
+    try {
+      await deleteCat(catDetail?.id);
+      toast({ description: '삭제되었습니다.', duration: 1000 });
+      router.replace('/zip');
+    } catch (e) {
+      toast({
+        description: '삭제에 실패했습니다. 잠시 후 다시 시도해주세요.',
+        duration: 1500
+      });
+    }
+  }, [catDetail?.id, toast, router]);
+
+  const handleEdit = useCallback(() => {
+    router.push(`/zip/${id}/edit?catId=${catDetail?.id}`);
+    setEditBottomSheet(false);
+  }, [router, id, catDetail?.id]);
+
+  return (
+    <>
+      <Topbar type="two">
+        <Topbar.Back onClick={() => router.back()} />
+        {catDetail?.isOwner ? (
+          <Topbar.More onClick={() => setEditBottomSheet(true)} />
+        ) : (
+          <Topbar.Empty />
+        )}
+      </Topbar>
+      <ZipDetailContent
+        catDetail={catDetail}
+        onCoParentsClick={handleCoParentsClick}
+        onShowCoParentsModal={() => setShowCoParentsModal(true)}
+      />
+      <MoreBtnBottomSheet
+        type="zip"
+        isVisible={editBottomSheet}
+        setIsVisible={() => setEditBottomSheet(!editBottomSheet)}
+        heightPercent={['50%', '40%']}
+        name={catDetail?.name}
+        memberId={catDetail?.id}
+        onDelete={handleDelete}
+        onEdit={handleEdit}
+      />
+      <CoParentsBottomSheet
+        isVisible={coParentsBottomSheet}
+        setIsVisible={() => setCoParentsBottomSheet(!coParentsBottomSheet)}
+        coParents={catDetail.coParents}
+      />
+      {showCoParentsModal && (
+        <FindCoParentsModal
+          setShowCoParentsModal={setShowCoParentsModal}
+          catId={catDetail.id}
+        />
+      )}
+    </>
+  );
+};
+
+export default ZipDetailClient;

--- a/src/components/zip/ZipDetailContent.tsx
+++ b/src/components/zip/ZipDetailContent.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import ZipDetailCatCard from './ZipDetailCatCard';
+import DetailCardLayout from './DetailCardLayout';
+import ZipDetailCoParents from './ZipDetailCoParents';
+import ZipDetailDiary from './ZipDetailDiary';
+import { CoParent } from '@/types/cat';
+import { DiaryObj } from '@/app/diary/diaryType';
+
+interface ZipDetailContentProps {
+  catDetail: any;
+  onCoParentsClick: () => void;
+  onShowCoParentsModal: () => void;
+}
+
+const ZipDetailContent = ({
+  catDetail,
+  onCoParentsClick,
+  onShowCoParentsModal
+}: ZipDetailContentProps) => {
+  return (
+    <section className="mx-auto flex h-screen max-w-[640px] flex-col gap-4 overflow-auto bg-gr-50 px-4 pb-32 pt-[72px]">
+      <article className="rounded-16">
+        <ZipDetailCatCard {...catDetail} />
+      </article>
+      <DetailCardLayout
+        titleObj={{
+          title: '공동집사',
+          onClick: onCoParentsClick
+        }}
+        btnObj={
+          catDetail.isOwner && {
+            text: '함께할 공동집사 찾기',
+            onClick: onShowCoParentsModal
+          }
+        }
+      >
+        <div className="flex pt-2">
+          {catDetail.coParents?.map((coParent: CoParent) => (
+            <ZipDetailCoParents key={coParent.memberId} {...coParent} />
+          ))}
+        </div>
+      </DetailCardLayout>
+      {catDetail.isAccessibleToDiaries && (
+        <DetailCardLayout
+          titleObj={{ title: '일지' }}
+          btnObj={{
+            text: '더보기',
+            onClick: () => {} // router.push는 클라이언트에서
+          }}
+        >
+          {catDetail.diaries?.slice(0, 3).map((diary: DiaryObj) => (
+            <Link href={`/diary/${diary.id}`} key={diary.id}>
+              <ZipDetailDiary {...diary} />
+            </Link>
+          ))}
+        </DetailCardLayout>
+      )}
+    </section>
+  );
+};
+
+export default ZipDetailContent;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,9 +5,11 @@ const PROTECTED_ROUTES: string[] = [
   '/diary',
   '/zip',
   '/community',
-  '/profile'
+  '/profile',
+  '/onboard',
+  '/cat-register'
 ];
-const PUBLIC_ROUTES: string[] = ['/signin', '/signup'];
+const PUBLIC_ROUTES: string[] = ['/signin', '/signup', '/reset-pwd'];
 
 export const middleware = async (
   request: NextRequest
@@ -48,7 +50,11 @@ const handlePublicAndProtectedRoutes = ({
   accessToken?: string;
   request: NextRequest;
 }): NextResponse => {
-  if (!accessToken && PROTECTED_ROUTES.includes(currentPath)) {
+  const isProtectedRoute = PROTECTED_ROUTES.some(
+    route => currentPath === route || currentPath.startsWith(route + '/')
+  );
+
+  if (!accessToken && isProtectedRoute) {
     return redirectToSignIn(request);
   }
 

--- a/src/providers/UserInfoProvider.tsx
+++ b/src/providers/UserInfoProvider.tsx
@@ -1,4 +1,4 @@
-'use clinet';
+'use client';
 
 import { UserProvider } from '@/contexts/EmailContext';
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,11 +1,22 @@
 import returnFetch from '@/utils/returnFetch';
 import returnFetchJson from '@/utils/returnFetchJson';
 
-const getTokenFromCookie = (): string | null => {
-  if (typeof document === 'undefined') return null;
+const getTokenFromCookie = async (): Promise<string | null> => {
+  if (typeof window === 'undefined') {
+    try {
+      const { cookies } = await import('next/headers');
+      const cookieStore = cookies();
+      const authCookie = cookieStore.get('Authorization');
+      return authCookie?.value || null;
+    } catch (error) {
+      console.warn('Failed to get cookie from server:', error);
+      return null;
+    }
+  }
 
-  const cookies = document.cookie.split(';');
-  const authCookie = cookies.find(cookie =>
+  const cookieString = document.cookie;
+  const cookieArray = cookieString.split(';');
+  const authCookie = cookieArray.find(cookie =>
     cookie.trim().startsWith('Authorization=')
   );
 
@@ -70,7 +81,7 @@ export const fetchAuth = returnFetch({
   baseUrl: process.env.NEXT_PUBLIC_MEOW_API + '/api/auth/v1.0.0',
   interceptors: {
     request: async ([url, requestInit], fetch) => {
-      let token = getTokenFromCookie();
+      let token = await getTokenFromCookie();
 
       if (!token || isTokenExpired(token)) {
         const newToken = await refreshTokenIfNeeded();
@@ -120,7 +131,7 @@ export const fetchAuthJson = returnFetchJson({
   headers: { Accept: 'application/json' },
   interceptors: {
     request: async ([url, requestInit], fetch) => {
-      let token = getTokenFromCookie();
+      let token = await getTokenFromCookie();
 
       if (!token || isTokenExpired(token)) {
         const newToken = await refreshTokenIfNeeded();


### PR DESCRIPTION
## Summary
일부 페이지들을 서버 컴포넌트로 전환하고 인증·경로 보호 로직을 개선했습니다. 

## Key Changes
- 인증/페치: getTokenFromCookie async, 서버에서 next/headers 동적 import → 401·번들 누수 방지
- 미들웨어: 동적 경로 보호(/diary/:id, /zip/:id), /onboard·/cat-register 보호 추가, /reset-pwd 공개
- 서버 컴포넌트 전환으로 커뮤니티/프로필/모음집(Zip)/고양이/일지/알림/설정을 서버 fetch + generateMetadata로 렌더링
    클라이언트는 CommunityDetailClient·DiaryDetailClient·ZipDetailClient·AlarmPageClient·SettingPageClient 등 인터렉  션만 담당하도록 분리.

## Impact
- 성능/UX: 초기 렌더 개선, 공유 메타(OG/Twitter) 안정화
- 보안/안정성: 인증 처리 정상화, 잘못된 라우팅 차단
